### PR TITLE
Specific command for editing and querying kernel parameters

### DIFF
--- a/cmd/kargs.go
+++ b/cmd/kargs.go
@@ -1,0 +1,120 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+
+	"github.com/spf13/cobra"
+	"github.com/vanilla-os/abroot/core"
+)
+
+func kargsUsage(*cobra.Command) error {
+	fmt.Print(`Description:
+	Manage kernel parameters.
+
+Usage:
+	kargs [action]
+
+Options:
+	--help/-h				show this message
+
+Actions:
+	get [present|future] 	get present/future root partition parameters
+	edit
+
+Examples:
+	abroot kargs edit
+	abroot kargs get future
+`)
+
+	return nil
+}
+
+func NewKargsCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "kargs",
+		Short: "Manage kernel parameters.",
+		RunE:  kargsCommand,
+	}
+	cmd.SetUsageFunc(kargsUsage)
+	cmd.Flags().SetInterspersed(false)
+
+	return cmd
+}
+
+func kargsCommand(cmd *cobra.Command, args []string) error {
+	if !core.RootCheck(true) {
+		return nil
+	}
+
+	if args[0] == "get" && len(args) == 1 {
+		fmt.Println("Please specify a state (present or future)")
+		return nil
+	}
+
+	switch args[0] {
+	case "get":
+		switch args[1] {
+		case "present":
+			kargs, err := core.GetCurrentKargs()
+			if err != nil {
+				return err
+			}
+
+			fmt.Printf("Current partition's parameters: %s\n", kargs)
+		case "future":
+			kargs, err := core.GetFutureKargs()
+			if err != nil {
+				return err
+			}
+
+			fmt.Printf("Future partition's parameters: %s\n", kargs)
+		default:
+			fmt.Printf("Unknown state: %s\n", args[1])
+		}
+	case "edit":
+		editor := os.Getenv("EDITOR")
+		if editor == "" {
+			editor = "nano"
+		}
+
+		// Create custom kargs file if non-existent
+		if _, err := os.Stat(core.KargsPath); os.IsNotExist(err) {
+			cmd := exec.Command("cp", core.KargsDefaultPath, core.KargsPath)
+			if err := cmd.Run(); err != nil {
+				return err
+			}
+		}
+
+        // Open a temporary file, so editors installed via apx can also be used
+        cmd := exec.Command("cp", core.KargsPath, "/tmp/kargs-temp")
+        if err := cmd.Run(); err != nil {
+            return err
+        }
+
+        // Call $EDITOR on temp file
+		cmd = exec.Command(editor, "/tmp/kargs-temp")
+		if err := cmd.Run(); err != nil {
+			return err
+		}
+
+        // Copy temp file back to /etc
+		cmd = exec.Command("cp", "/tmp/kargs-temp", core.KargsPath)
+		if err := cmd.Run(); err != nil {
+			return err
+		}
+
+        // Run something just to trigger a transaction
+        if _, err := core.TransactionalExec("echo"); err != nil {
+            fmt.Println("Failed to start transactional shell:", err)
+            os.Exit(1)
+        }
+
+        fmt.Println("Kernel parameters will be applied on next boot.")
+	default:
+		fmt.Printf("Unknown parameter: %s\n", args[0])
+	}
+
+	return nil
+}

--- a/cmd/kargs.go
+++ b/cmd/kargs.go
@@ -74,50 +74,55 @@ func kargsCommand(cmd *cobra.Command, args []string) error {
 			fmt.Printf("Unknown state: %s\n", args[1])
 		}
 	case "edit":
-		editor := os.Getenv("EDITOR")
-		if editor == "" {
-			editor = "nano"
-		}
-
-		// Create custom kargs file if non-existent
-		if _, err := os.Stat(core.KargsPath); os.IsNotExist(err) {
-			cmd := exec.Command("cp", core.KargsDefaultPath, core.KargsPath)
-			if err := cmd.Run(); err != nil {
-				return err
-			}
-		}
-
-		// Open a temporary file, so editors installed via apx can also be used
-		cmd := exec.Command("cp", core.KargsPath, "/tmp/kargs-temp")
-		if err := cmd.Run(); err != nil {
-			return err
-		}
-
-		// Call $EDITOR on temp file
-		cmd = exec.Command(editor, "/tmp/kargs-temp")
-		cmd.Stdin = os.Stdin
-		cmd.Stdout = os.Stdout
-		cmd.Stderr = os.Stderr
-		if err := cmd.Run(); err != nil {
-			return err
-		}
-
-		// Copy temp file back to /etc
-		cmd = exec.Command("cp", "/tmp/kargs-temp", core.KargsPath)
-		if err := cmd.Run(); err != nil {
-			return err
-		}
-
-		// Run something just to trigger a transaction
-		if _, err := core.TransactionalExec("echo"); err != nil {
-			fmt.Println("Failed to start transactional shell:", err)
-			os.Exit(1)
-		}
-
-		fmt.Println("Kernel parameters will be applied on next boot.")
+		kargs_edit()
 	default:
 		fmt.Printf("Unknown parameter: %s\n", args[0])
 	}
 
+	return nil
+}
+
+func kargs_edit() error {
+	editor := os.Getenv("EDITOR")
+	if editor == "" {
+		editor = "nano"
+	}
+
+	// Create custom kargs file if non-existent
+	if _, err := os.Stat(core.KargsPath); os.IsNotExist(err) {
+		cmd := exec.Command("cp", core.KargsDefaultPath, core.KargsPath)
+		if err := cmd.Run(); err != nil {
+			return err
+		}
+	}
+
+	// Open a temporary file, so editors installed via apx can also be used
+	cmd := exec.Command("cp", core.KargsPath, "/tmp/kargs-temp")
+	if err := cmd.Run(); err != nil {
+		return err
+	}
+
+	// Call $EDITOR on temp file
+	cmd = exec.Command(editor, "/tmp/kargs-temp")
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return err
+	}
+
+	// Copy temp file back to /etc
+	cmd = exec.Command("cp", "/tmp/kargs-temp", core.KargsPath)
+	if err := cmd.Run(); err != nil {
+		return err
+	}
+
+	// Run something just to trigger a transaction
+	if _, err := core.TransactionalExec("echo"); err != nil {
+		fmt.Println("Failed to start transactional shell:", err)
+		os.Exit(1)
+	}
+
+	fmt.Println("Kernel parameters will be applied on next boot.")
 	return nil
 }

--- a/cmd/kargs.go
+++ b/cmd/kargs.go
@@ -87,34 +87,34 @@ func kargsCommand(cmd *cobra.Command, args []string) error {
 			}
 		}
 
-        // Open a temporary file, so editors installed via apx can also be used
-        cmd := exec.Command("cp", core.KargsPath, "/tmp/kargs-temp")
-        if err := cmd.Run(); err != nil {
-            return err
-        }
-
-        // Call $EDITOR on temp file
-		cmd = exec.Command(editor, "/tmp/kargs-temp")
-        cmd.Stdin = os.Stdin
-        cmd.Stdout = os.Stdout
-        cmd.Stderr = os.Stderr
+		// Open a temporary file, so editors installed via apx can also be used
+		cmd := exec.Command("cp", core.KargsPath, "/tmp/kargs-temp")
 		if err := cmd.Run(); err != nil {
 			return err
 		}
 
-        // Copy temp file back to /etc
+		// Call $EDITOR on temp file
+		cmd = exec.Command(editor, "/tmp/kargs-temp")
+		cmd.Stdin = os.Stdin
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+		if err := cmd.Run(); err != nil {
+			return err
+		}
+
+		// Copy temp file back to /etc
 		cmd = exec.Command("cp", "/tmp/kargs-temp", core.KargsPath)
 		if err := cmd.Run(); err != nil {
 			return err
 		}
 
-        // Run something just to trigger a transaction
-        if _, err := core.TransactionalExec("echo"); err != nil {
-            fmt.Println("Failed to start transactional shell:", err)
-            os.Exit(1)
-        }
+		// Run something just to trigger a transaction
+		if _, err := core.TransactionalExec("echo"); err != nil {
+			fmt.Println("Failed to start transactional shell:", err)
+			os.Exit(1)
+		}
 
-        fmt.Println("Kernel parameters will be applied on next boot.")
+		fmt.Println("Kernel parameters will be applied on next boot.")
 	default:
 		fmt.Printf("Unknown parameter: %s\n", args[0])
 	}

--- a/cmd/kargs.go
+++ b/cmd/kargs.go
@@ -62,14 +62,14 @@ func kargsCommand(cmd *cobra.Command, args []string) error {
 				return err
 			}
 
-			fmt.Printf("Current partition's parameters: %s\n", kargs)
+			fmt.Printf("Current partition's parameters:\n%s\n", kargs)
 		case "future":
 			kargs, err := core.GetFutureKargs()
 			if err != nil {
 				return err
 			}
 
-			fmt.Printf("Future partition's parameters: %s\n", kargs)
+			fmt.Printf("Future partition's parameters:\n%s\n", kargs)
 		default:
 			fmt.Printf("Unknown state: %s\n", args[1])
 		}
@@ -95,6 +95,9 @@ func kargsCommand(cmd *cobra.Command, args []string) error {
 
         // Call $EDITOR on temp file
 		cmd = exec.Command(editor, "/tmp/kargs-temp")
+        cmd.Stdin = os.Stdin
+        cmd.Stdout = os.Stdout
+        cmd.Stderr = os.Stderr
 		if err := cmd.Run(); err != nil {
 			return err
 		}

--- a/cmd/update-boot.go
+++ b/cmd/update-boot.go
@@ -48,7 +48,7 @@ command should be used by advanced users for maintenance purposes.`) {
 		}
 	}
 
-	kargs, err := core.GetKargs()
+	kargs, err := core.ReadKargsFile()
 	if err != nil {
 		return err
 	}

--- a/core/transaction.go
+++ b/core/transaction.go
@@ -10,8 +10,8 @@ import (
 var (
 	lockPath         = "/tmp/abroot-transactions.lock"
 	startRulesPath   = "/etc/abroot/start-transaction-rules.d/"
-	kargsPath        = "/etc/abroot/kargs"
-	kargsDefaultPath = "/etc/default/abroot_kargs"
+	KargsPath        = "/etc/abroot/kargs"
+	KargsDefaultPath = "/etc/default/abroot_kargs"
 	endRulesPath     = "/etc/abroot/end-transaction-rules.d/"
 )
 
@@ -57,15 +57,15 @@ func AreTransactionsLocked() bool {
 	return true
 }
 
-// GetKargs reads kernel arguments from file. If no kargs file exists,
+// ReadKargsFile reads kernel arguments from file. If no kargs file exists,
 // it reads from kargs.default.
-func GetKargs() (string, error) {
+func ReadKargsFile() (string, error) {
 	PrintVerbose("step:  GetKargs")
 	content := []byte{}
-	content, err := os.ReadFile(kargsPath)
+	content, err := os.ReadFile(KargsPath)
 	if err != nil {
 		var default_err error
-		content, default_err = os.ReadFile(kargsDefaultPath)
+		content, default_err = os.ReadFile(KargsDefaultPath)
 		if default_err != nil {
 			return "", default_err
 		}
@@ -160,7 +160,7 @@ func ApplyTransaction() error {
 	}
 
 	PrintVerbose("step:  UpdateRootBoot")
-	kargs, err := GetKargs()
+	kargs, err := ReadKargsFile()
 	if err != nil {
 		_ = CancelTransaction()
 		return err

--- a/main.go
+++ b/main.go
@@ -41,6 +41,7 @@ func main() {
 
 	rootCmd.AddCommand(cmd.NewUpdateBootCommand())
 	rootCmd.AddCommand(cmd.NewGetCommand())
+	rootCmd.AddCommand(cmd.NewKargsCommand())
 	rootCmd.AddCommand(cmd.NewShellCommand())
 	rootCmd.AddCommand(cmd.NewExecCommand())
 	rootCmd.SetHelpFunc(help)


### PR DESCRIPTION
Adds `kargs get [present|future]` and `kargs edit` for reading and modifying, respectively, kernel parameters.