### PR TITLE
Inform user that diff is running

### DIFF
--- a/core/transaction.go
+++ b/core/transaction.go
@@ -194,12 +194,12 @@ func ApplyTransaction() error {
 // from the lastest transaction.
 func TransactionDiff() {
 	PrintVerbose("step:  TransactionDiff")
-	cmdr.Info.Println("Gathering changes made by transaction...")
 	if !AreTransactionsLocked() {
 		cmdr.Warning.Println("No transaction has been made since last reboot. Nothing to diff.")
 		return
 	}
 
+	spinner, _ := cmdr.Spinner.Start("Gathering changes made by transaction...")
 	cmd := exec.Command("diff", "-qr", "/.system", "/partFuture")
 
 	// force english locale because output changes based on language
@@ -225,6 +225,7 @@ func TransactionDiff() {
 			}
 		}
 	}
+	spinner.Success()
 
 	var bullet_items []cmdr.BulletListItem
 	style := cmdr.NewStyle(cmdr.Bold, cmdr.FgRed)

--- a/core/transaction.go
+++ b/core/transaction.go
@@ -194,6 +194,7 @@ func ApplyTransaction() error {
 // from the lastest transaction.
 func TransactionDiff() {
 	PrintVerbose("step:  TransactionDiff")
+	cmdr.Info.Println("Gathering changes made by transaction...")
 	if !AreTransactionsLocked() {
 		cmdr.Warning.Println("No transaction has been made since last reboot. Nothing to diff.")
 		return


### PR DESCRIPTION
The `diff` command can take a few seconds to run, so it's good to inform the user that ABroot is doing something and hasn't frozen