### PR TITLE
Block kargs edit if transactions are locked

### DIFF
--- a/cmd/kargs.go
+++ b/cmd/kargs.go
@@ -17,10 +17,6 @@ func NewKargsCommand() *cmdr.Command {
 }
 
 func kargsCommand(cmd *cobra.Command, args []string) error {
-	if !core.RootCheck(false) {
-		cmdr.Error.Println(abroot.Trans("kargs.rootRequired"))
-		return nil
-	}
 	if args[0] == "get" && len(args) == 1 {
 		cmdr.Error.Println(abroot.Trans("kargs.stateRequired"))
 		return nil
@@ -56,6 +52,16 @@ func kargsCommand(cmd *cobra.Command, args []string) error {
 }
 
 func kargs_edit() error {
+	if !core.RootCheck(false) {
+		cmdr.Error.Println(abroot.Trans("kargs.rootRequired"))
+		return nil
+	}
+
+	if core.AreTransactionsLocked() {
+		cmdr.Error.Printf(abroot.Trans("kargs.transactionsLocked"))
+		return nil
+	}
+
 	editor := os.Getenv("EDITOR")
 	if editor == "" {
 		editor = "nano"

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -30,6 +30,7 @@ kargs:
   futureParams: "Future partition's parameters:\n%s\n"
   unknownState: "Unknown state: %s\n"
   unknownParam: "Unknown parameter: %s\n"
+  transactionsLocked: "Another transaction has already been executed, you must reboot your system before starting a new transaction."
 
 edit:
   use: "edit"


### PR DESCRIPTION
Check if transactions are locked before allowing the user to edit kernel parameters.