### PR TITLE
Rollback

### DIFF
--- a/cmd/rollback.go
+++ b/cmd/rollback.go
@@ -1,0 +1,34 @@
+package cmd
+
+import (
+
+	"github.com/spf13/cobra"
+	"github.com/vanilla-os/abroot/core"
+	"github.com/vanilla-os/orchid/cmdr"
+)
+
+func NewRollbackCommand() *cmdr.Command {
+	cmd := cmdr.NewCommand(
+		"rollback",
+		abroot.Trans("rollback.long"),
+		abroot.Trans("rollback.short"),
+		rollbackCommand,
+	)
+	cmd.Example = "abroot rollback"
+	cmd.Flags().SetInterspersed(false)
+	return cmd
+}
+
+func rollbackCommand(cmd *cobra.Command, args []string) error {
+	if !core.RootCheck(true) {
+		cmdr.Error.Println(abroot.Trans("rollback.rootRequired"))
+		return nil
+	}
+
+    err := core.Rollback()
+    if err != nil {
+        return err
+    }
+
+	return nil
+}

--- a/core/root.go
+++ b/core/root.go
@@ -767,26 +767,37 @@ func Rollback() error {
 		previous_root = "a"
 	}
 
+	bold := cmdr.Bold.Sprint
+	red := cmdr.Red
+	green := cmdr.Green
+
+	var currently_booted_root_colored string
 	var rollback_kargs string
 	if current_root == currently_booted_root {
 		rollback_kargs, err = GetFutureKargs()
 		if err != nil {
 			return err
 		}
+		currently_booted_root_colored = red(strings.ToUpper(currently_booted_root))
 	} else {
 		rollback_kargs, err = GetCurrentKargs()
 		if err != nil {
 			return err
 		}
+		currently_booted_root_colored = green(strings.ToUpper(currently_booted_root))
 	}
 
 	message := fmt.Sprintf(`
-        You are currently in partition %s
-        Your "present" partition is %s
+You are currently in partition %s
+Your "present" partition is %s
 
-        This command will make %s the present partition again. Any changes made to %s will be lost.
-        Continue?
-    `, strings.ToUpper(currently_booted_root), strings.ToUpper(current_root), strings.ToLower(previous_root), strings.ToLower(current_root))
+This command will make %s the present partition again. Any changes made to %s will be lost.
+Continue?`,
+		bold(currently_booted_root_colored),
+		bold(red(strings.ToUpper(current_root))),
+		bold(green(strings.ToUpper(previous_root))),
+		bold(red(strings.ToUpper(current_root))),
+	)
 
 	confirmation, err := cmdr.Confirm.Show(message)
 	if err != nil {
@@ -795,6 +806,7 @@ func Rollback() error {
 
 	if confirmation {
 		UpdateRootBoot(false, rollback_kargs)
+		cmdr.Success.Println("Rollback complete. Reboot your system to apply changes.")
 	}
 
 	return nil

--- a/core/root.go
+++ b/core/root.go
@@ -309,15 +309,13 @@ func GetKargs(state string) (string, error) {
 	case "present":
 		if presentLabel == "a" {
 			return kargs_lines[0], nil
-		} else {
-			return kargs_lines[1], nil
 		}
+		return kargs_lines[1], nil
 	case "future":
 		if presentLabel == "a" {
 			return kargs_lines[1], nil
-		} else {
-			return kargs_lines[0], nil
 		}
+		return kargs_lines[0], nil
 	default:
 		return "", errors.New(fmt.Sprintf("Invalid state %s", state))
 	}

--- a/core/root.go
+++ b/core/root.go
@@ -301,23 +301,23 @@ func GetKargs(state string) (string, error) {
 	}
 
 	presentLabel, err := GetPresentRootLabel()
-    if err != nil {
-        return "", err
-    }
+	if err != nil {
+		return "", err
+	}
 
 	switch state {
 	case "present":
-        if presentLabel == "a" {
-		    return kargs_lines[0], nil
-        } else {
-		    return kargs_lines[1], nil
-        }
+		if presentLabel == "a" {
+			return kargs_lines[0], nil
+		} else {
+			return kargs_lines[1], nil
+		}
 	case "future":
-        if presentLabel == "a" {
-		    return kargs_lines[1], nil
-        } else {
-		    return kargs_lines[0], nil
-        }
+		if presentLabel == "a" {
+			return kargs_lines[1], nil
+		} else {
+			return kargs_lines[0], nil
+		}
 	default:
 		return "", errors.New(fmt.Sprintf("Invalid state %s", state))
 	}
@@ -767,26 +767,26 @@ func Rollback() error {
 		previous_root = "a"
 	}
 
-    var rollback_kargs string
-    if current_root == currently_booted_root {
-        rollback_kargs, err = GetFutureKargs()
-        if err != nil {
-            return err
-        }
-    } else {
-        rollback_kargs, err = GetCurrentKargs()
-        if err != nil {
-            return err
-        }
-    }
+	var rollback_kargs string
+	if current_root == currently_booted_root {
+		rollback_kargs, err = GetFutureKargs()
+		if err != nil {
+			return err
+		}
+	} else {
+		rollback_kargs, err = GetCurrentKargs()
+		if err != nil {
+			return err
+		}
+	}
 
 	message := fmt.Sprintf(`
         You are currently in partition %s
         Your "present" partition is %s
 
-        This command will make %s the present partition again. Any changes made to B will be lost.
+        This command will make %s the present partition again. Any changes made to %s will be lost.
         Continue?
-    `, strings.ToUpper(currently_booted_root), strings.ToUpper(current_root), strings.ToLower(previous_root))
+    `, strings.ToUpper(currently_booted_root), strings.ToUpper(current_root), strings.ToLower(previous_root), strings.ToLower(current_root))
 
 	confirmation, err := cmdr.Confirm.Show(message)
 	if err != nil {
@@ -794,7 +794,7 @@ func Rollback() error {
 	}
 
 	if confirmation {
-        UpdateRootBoot(false, rollback_kargs)
+		UpdateRootBoot(false, rollback_kargs)
 	}
 
 	return nil

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -63,3 +63,9 @@ diff:
   long: "List modifications made to the filesystem in the latest transiction"
   short: "Show modifications from latest transaction."
   rootRequired: "You must be root to run this command."
+
+rollback:
+  use: "rollback"
+  long: "Executes a system rollback, discarding changes made to the present root."
+  short: "Return the system to a previous state."
+  rootRequired: "You must be root to run this command."

--- a/main.go
+++ b/main.go
@@ -42,6 +42,9 @@ func main() {
 	diffCmd := cmd.NewDiffCommand()
 	root.AddCommand(diffCmd)
 
+	rollbackCmd := cmd.NewRollbackCommand()
+	root.AddCommand(rollbackCmd)
+
 	// run the app
 	err := abroot.Run()
 	if err != nil {


### PR DESCRIPTION
Adds a `rollback` command to ABroot, which returns to the previous state. 

I've tested on a VM and everything seems to work, but some extra testing would be appreciated. This is not something that can be shipped with errors because of its breakage potential.

Fixes #29.