### PR TITLE
fix: remove /run from mountpoints. Fix apt/systemd problems in chroot.

### DIFF
--- a/cmd/diff.go
+++ b/cmd/diff.go
@@ -15,6 +15,7 @@ func NewDiffCommand() *cmdr.Command {
 	)
 	cmd.Example = "abroot diff"
 	cmd.Flags().SetInterspersed(false)
+
 	return cmd
 }
 

--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -33,6 +33,7 @@ func NewExecCommand() *cmdr.Command {
 	cmd.Args = cobra.MinimumNArgs(1)
 	cmd.Example = "abroot exec apt-get update"
 	cmd.Flags().SetInterspersed(false)
+
 	return cmd
 }
 
@@ -45,9 +46,11 @@ func execCommand(cmd *cobra.Command, args []string) error {
 	forceRun := cmdr.FlagValBool("force-run")
 	if !forceRun {
 		b, err := cmdr.Confirm.Show(abroot.Trans("exec.confirm"))
+
 		if err != nil {
 			return err
 		}
+
 		if !b {
 			return nil
 		}

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -19,6 +19,7 @@ func NewGetCommand() *cmdr.Command {
 	cmd.Args = cobra.MatchAll(cobra.ExactArgs(1), cobra.OnlyValidArgs)
 	cmd.Example = "abroot get present\nabroot get future"
 	cmd.ValidArgs = validArgs
+
 	return cmd
 }
 
@@ -37,13 +38,16 @@ func get(cmd *cobra.Command, args []string) error {
 			cmdr.Error.Println("Error getting present root partition.")
 			return err
 		}
+
 		cmdr.Info.Printf(template, "Present", presentLabel)
+
 	case "future":
 		futureLabel, err := core.GetFutureRootLabel()
 		if err != nil {
 			cmdr.Error.Println("Error getting future root partition.")
 			return err
 		}
+
 		cmdr.Info.Printf(template, "Future", futureLabel)
 	default:
 		cmdr.Error.Printf("Unknown state: %s\n", args[0])

--- a/cmd/kargs.go
+++ b/cmd/kargs.go
@@ -10,9 +10,9 @@ import (
 )
 
 func NewKargsCommand() *cmdr.Command {
-
 	kargs := cmdr.NewCommand("kargs [edit|get] <partition>", abroot.Trans("kargs.long"), abroot.Trans("kargs.short"), kargsCommand)
 	kargs.Example = "abroot kargs edit\nabroot kargs get future"
+
 	return kargs
 }
 
@@ -43,7 +43,10 @@ func kargsCommand(cmd *cobra.Command, args []string) error {
 			cmdr.Error.Printf(abroot.Trans("kargs.unknownState"), args[1])
 		}
 	case "edit":
-		kargs_edit()
+		err := kargsEdit()
+		if err != nil {
+			return nil
+		}
 	default:
 		cmdr.Error.Printf(abroot.Trans("kargs.unknownParam"), args[0])
 	}
@@ -51,7 +54,7 @@ func kargsCommand(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-func kargs_edit() error {
+func kargsEdit() error {
 	if !core.RootCheck(false) {
 		cmdr.Error.Println(abroot.Trans("kargs.rootRequired"))
 		return nil
@@ -70,14 +73,18 @@ func kargs_edit() error {
 	// Create custom kargs file if non-existent
 	if _, err := os.Stat(core.KargsPath); os.IsNotExist(err) {
 		cmd := exec.Command("cp", core.KargsDefaultPath, core.KargsPath)
-		if err := cmd.Run(); err != nil {
+
+		err := cmd.Run()
+		if err != nil {
 			return err
 		}
 	}
 
 	// Open a temporary file, so editors installed via apx can also be used
 	cmd := exec.Command("cp", core.KargsPath, "/tmp/kargs-temp")
-	if err := cmd.Run(); err != nil {
+
+	err := cmd.Run()
+	if err != nil {
 		return err
 	}
 
@@ -86,13 +93,17 @@ func kargs_edit() error {
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
-	if err := cmd.Run(); err != nil {
+
+	err = cmd.Run()
+	if err != nil {
 		return err
 	}
 
 	// Copy temp file back to /etc
 	cmd = exec.Command("cp", "/tmp/kargs-temp", core.KargsPath)
-	if err := cmd.Run(); err != nil {
+
+	err = cmd.Run()
+	if err != nil {
 		return err
 	}
 
@@ -103,5 +114,6 @@ func kargs_edit() error {
 	}
 
 	cmdr.Info.Println(abroot.Trans("kargs.nextReboot"))
+
 	return nil
 }

--- a/cmd/rollback.go
+++ b/cmd/rollback.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-
 	"github.com/spf13/cobra"
 	"github.com/vanilla-os/abroot/core"
 	"github.com/vanilla-os/orchid/cmdr"
@@ -16,6 +15,7 @@ func NewRollbackCommand() *cmdr.Command {
 	)
 	cmd.Example = "abroot rollback"
 	cmd.Flags().SetInterspersed(false)
+
 	return cmd
 }
 
@@ -25,10 +25,10 @@ func rollbackCommand(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
-    err := core.Rollback()
-    if err != nil {
-        return err
-    }
+	err := core.Rollback()
+	if err != nil {
+		return err
+	}
 
 	return nil
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -29,5 +29,6 @@ func NewRootCommand(version string) *cmdr.Command {
 				abroot.Trans("abroot.verboseFlag"),
 				false))
 	root.Version = version
+
 	return root
 }

--- a/cmd/shell.go
+++ b/cmd/shell.go
@@ -21,6 +21,7 @@ func NewShellCommand() *cmdr.Command {
 			abroot.Trans("shell.forceOpenFlag"),
 			false))
 	shell.Example = "abroot shell"
+
 	return shell
 }
 
@@ -29,12 +30,15 @@ func shell(cmd *cobra.Command, args []string) error {
 		cmdr.Error.Println(abroot.Trans("shell.rootRequired"))
 		return nil
 	}
+
 	forceOpen := cmdr.FlagValBool("force-open")
 	if !forceOpen {
 		b, err := cmdr.Confirm.Show(abroot.Trans("shell.confirm"))
+
 		if err != nil {
 			return err
 		}
+
 		if !b {
 			return nil
 		}
@@ -46,6 +50,7 @@ func shell(cmd *cobra.Command, args []string) error {
 		cmdr.Error.Println(abroot.Trans("shell.failed"), err)
 		os.Exit(1)
 	}
+
 	core.TransactionDiff()
 
 	cmdr.Success.Println(abroot.Trans("shell.success"))

--- a/cmd/update-boot.go
+++ b/cmd/update-boot.go
@@ -20,6 +20,7 @@ func NewUpdateBootCommand() *cmdr.Command {
 			false))
 	// don't show this command in usage/help unless specified
 	upd.Hidden = true
+
 	return upd
 }
 
@@ -28,13 +29,14 @@ func status(cmd *cobra.Command, args []string) error {
 		cmdr.Error.Println(abroot.Trans("update.rootRequired"))
 		return nil
 	}
-	forceUpdate := cmdr.FlagValBool("force-update")
 
+	forceUpdate := cmdr.FlagValBool("force-update")
 	if !forceUpdate {
 		b, err := cmdr.Confirm.Show(abroot.Trans("update.confirm"))
 		if err != nil {
 			return err
 		}
+
 		if !b {
 			return nil
 		}
@@ -44,8 +46,9 @@ func status(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	if update_err := core.UpdateRootBoot(false, kargs); update_err != nil {
-		return update_err
+
+	if updateErr := core.UpdateRootBoot(false, kargs); updateErr != nil {
+		return updateErr
 	}
 
 	return nil

--- a/core/root.go
+++ b/core/root.go
@@ -715,7 +715,6 @@ func updateGrubConfig() error {
 		{"mount", "-t", "proc", "/proc", "/partFuture/proc"},
 		{"mount", "-t", "sysfs", "/sys", "/partFuture/sys"},
 		{"mount", "--rbind", "/dev", "/partFuture/dev"},
-		{"mount", "--rbind", "/run", "/partFuture/run"},
 		{"mount", "--rbind", "/sys/firmware/efi/efivars", "/partFuture/sys/firmware/efi/efivars"},
 	}
 	for _, command := range commandList {

--- a/core/root.go
+++ b/core/root.go
@@ -3,7 +3,6 @@ package core
 import (
 	"bufio"
 	"bytes"
-	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -35,6 +34,7 @@ func getRootDevice(state string) (string, error) {
 		if err != nil {
 			return "", err
 		}
+
 		return device, nil
 	}
 
@@ -43,6 +43,7 @@ func getRootDevice(state string) (string, error) {
 		if err != nil {
 			return "", err
 		}
+
 		return device, nil
 	}
 
@@ -51,6 +52,7 @@ func getRootDevice(state string) (string, error) {
 		if err != nil {
 			return "", err
 		}
+
 		return device, nil
 	}
 
@@ -75,6 +77,7 @@ func getCurrentRootLabel() (string, error) {
 
 	label := strings.TrimSpace(string(out))
 	label = strings.ToLower(label)
+
 	return label, nil
 }
 
@@ -93,6 +96,7 @@ func GetDeviceByMountPoint(mountPoint string) (string, error) {
 		if len(split) != 2 {
 			continue
 		}
+
 		if strings.HasSuffix(split[0], mountPoint) {
 			return "/dev/" + split[1], nil
 		}
@@ -116,6 +120,7 @@ func getDeviceByLabel(label string) (string, error) {
 		if len(split) != 2 {
 			continue
 		}
+
 		if split[0] == label {
 			return "/dev/" + split[1], nil
 		}
@@ -140,6 +145,7 @@ func getRootUUID(state string) (string, error) {
 	}
 
 	uuid := strings.TrimSpace(string(out))
+
 	return uuid, nil
 }
 
@@ -157,6 +163,7 @@ func GetBootUUID() (string, error) {
 	}
 
 	cmd := exec.Command("lsblk", "-o", "UUID", "-n", device)
+
 	out, err := cmd.Output()
 	if err != nil {
 		PrintVerbose("err:GetBootUUID: %s", err)
@@ -164,6 +171,7 @@ func GetBootUUID() (string, error) {
 	}
 
 	uuid := strings.TrimSpace(string(out))
+
 	return uuid, nil
 }
 
@@ -181,6 +189,7 @@ func GetEfiUUID() (string, error) {
 	}
 
 	cmd := exec.Command("lsblk", "-o", "UUID", "-n", device)
+
 	out, err := cmd.Output()
 	if err != nil {
 		PrintVerbose("err:GetEfiUUID: %s", err)
@@ -188,6 +197,7 @@ func GetEfiUUID() (string, error) {
 	}
 
 	uuid := strings.TrimSpace(string(out))
+
 	return uuid, nil
 }
 
@@ -234,29 +244,31 @@ func getRootFileSystem(state string) (string, error) {
 // MountFutureRoot mounts the future root partition to /partB.
 func MountFutureRoot() error {
 	PrintVerbose("step:  GetFutureRootDevice")
+
 	device, err := GetFutureRootDevice()
 	if err != nil {
 		return err
 	}
 
 	PrintVerbose("step:  getRootFileSystem")
-	if err != nil {
-		return err
-	}
 
-	if _, err := os.Stat("/partFuture"); !os.IsNotExist(err) {
+	_, err = os.Stat("/partFuture")
+	if !os.IsNotExist(err) {
 		PrintVerbose("step:  IsMounted")
+
 		if IsMounted("/partFuture") {
 			return fmt.Errorf("future root partition is busy. Another transaction?")
 		}
 
-		if err := os.RemoveAll("/partFuture"); err != nil {
+		err = os.RemoveAll("/partFuture")
+		if err != nil {
 			PrintVerbose("err:MountFutureRoot: %s", err)
 			return err
 		}
 	}
 
-	if err := os.Mkdir("/partFuture", 0755); err != nil {
+	err = os.Mkdir("/partFuture", 0755)
+	if err != nil {
 		PrintVerbose("err:MountFutureRoot: %s", err)
 		return err
 	}
@@ -266,7 +278,9 @@ func MountFutureRoot() error {
 	cmd := exec.Command("mount", device, "/partFuture")
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
-	if err := cmd.Run(); err != nil {
+
+	err = cmd.Run()
+	if err != nil {
 		PrintVerbose("err:MountFutureRoot: %s", err)
 		return err
 	}
@@ -276,7 +290,8 @@ func MountFutureRoot() error {
 
 // UnmountFutureRoot unmounts the future root partition.
 func UnmountFutureRoot() error {
-	if err := exec.Command("umount", "-l", "/partFuture").Run(); err != nil {
+	err := exec.Command("umount", "-l", "/partFuture").Run()
+	if err != nil {
 		PrintVerbose("err:UnmountFutureRoot: %s", err)
 		return err
 	}
@@ -291,12 +306,13 @@ func GetKargs(state string) (string, error) {
 		return "", err
 	}
 
-	var kargs_lines []string
+	var kargsLines []string
+
 	scanner := bufio.NewScanner(file)
 	for scanner.Scan() {
 		if strings.Contains(scanner.Text(), "linux\t/vmlinuz") {
 			splits := strings.Split(scanner.Text(), " ")
-			kargs_lines = append(kargs_lines, strings.Join(splits[2:len(splits)-1], " "))
+			kargsLines = append(kargsLines, strings.Join(splits[2:len(splits)-1], " "))
 		}
 	}
 
@@ -308,16 +324,18 @@ func GetKargs(state string) (string, error) {
 	switch state {
 	case "present":
 		if presentLabel == "a" {
-			return kargs_lines[0], nil
+			return kargsLines[0], nil
 		}
-		return kargs_lines[1], nil
+
+		return kargsLines[1], nil
 	case "future":
 		if presentLabel == "a" {
-			return kargs_lines[1], nil
+			return kargsLines[1], nil
 		}
-		return kargs_lines[0], nil
+
+		return kargsLines[0], nil
 	default:
-		return "", errors.New(fmt.Sprintf("Invalid state %s", state))
+		return "", fmt.Errorf("Invalid state %s", state)
 	}
 }
 
@@ -342,30 +360,35 @@ func UpdateRootBoot(transacting bool, kargs string) error {
 	unwanted := []string{"10_linux", "20_memtest86+"} // those files cause undesired boot entries
 
 	PrintVerbose("step:  GetPresentRootLabel")
+
 	presentLabel, err := GetPresentRootLabel()
 	if err != nil {
 		return err
 	}
 
 	PrintVerbose("step:  GetFutureRootLabel")
+
 	futureLabel, err := GetFutureRootLabel()
 	if err != nil {
 		return err
 	}
 
 	PrintVerbose("step:  GetPresentRootUUID")
+
 	presentUUID, err := GetPresentRootUUID()
 	if err != nil {
 		return err
 	}
 
 	PrintVerbose("step:  GetFutureRootUUID")
+
 	futureUUID, err := GetFutureRootUUID()
 	if err != nil {
 		return err
 	}
 
 	PrintVerbose("step:  GetBootUUID")
+
 	bootUUID, err := GetBootUUID()
 	if err != nil {
 		return err
@@ -373,7 +396,9 @@ func UpdateRootBoot(transacting bool, kargs string) error {
 
 	if !transacting {
 		PrintVerbose("step:  MountFutureRoot")
-		if err := MountFutureRoot(); err != nil {
+
+		err = MountFutureRoot()
+		if err != nil {
 			return err
 		}
 	}
@@ -427,7 +452,9 @@ export linux_gfx_mode
 	initrd  /initrd.img-%s
 }
 `
+
 	PrintVerbose("step:  getKernelVersion present")
+
 	presentKernelVersion, err := getKernelVersion("present")
 	if err != nil {
 		PrintVerbose("err:UpdateRootBoot: %s", err)
@@ -435,62 +462,77 @@ export linux_gfx_mode
 	}
 
 	PrintVerbose("step:  getKernelVersion future")
+
 	futureKernelVersion, err := getKernelVersion("future")
 	if err != nil {
 		PrintVerbose("err:UpdateRootBoot: %s", err)
 		return err
 	}
 
-	old_kargs, err := GetCurrentKargs()
+	oldKargs, err := GetCurrentKargs()
 	if err != nil {
 		return err
 	}
 
-	var boot_a, boot_b string
+	var bootA, bootB string
 	if presentLabel == "a" {
-		boot_a = fmt.Sprintf(bootEntry, presentLabel, "previous", bootUUID, presentKernelVersion, presentUUID, old_kargs, presentKernelVersion)
-		boot_b = fmt.Sprintf(bootEntry, futureLabel, "current", bootUUID, futureKernelVersion, futureUUID, kargs, futureKernelVersion)
+		bootA = fmt.Sprintf(bootEntry, presentLabel, "previous", bootUUID, presentKernelVersion, presentUUID, oldKargs, presentKernelVersion)
+		bootB = fmt.Sprintf(bootEntry, futureLabel, "current", bootUUID, futureKernelVersion, futureUUID, kargs, futureKernelVersion)
 	} else {
-		boot_a = fmt.Sprintf(bootEntry, futureLabel, "current", bootUUID, futureKernelVersion, futureUUID, kargs, futureKernelVersion)
-		boot_b = fmt.Sprintf(bootEntry, presentLabel, "previous", bootUUID, presentKernelVersion, presentUUID, old_kargs, presentKernelVersion)
+		bootA = fmt.Sprintf(bootEntry, futureLabel, "current", bootUUID, futureKernelVersion, futureUUID, kargs, futureKernelVersion)
+		bootB = fmt.Sprintf(bootEntry, presentLabel, "previous", bootUUID, presentKernelVersion, presentUUID, oldKargs, presentKernelVersion)
 	}
-	bootTemplate := fmt.Sprintf("%s\n%s\n%s", bootHeader, boot_a, boot_b)
+
+	bootTemplate := fmt.Sprintf("%s\n%s\n%s", bootHeader, bootA, bootB)
 
 	PrintVerbose("step:  WriteFile future")
-	if err := os.WriteFile("/partFuture/etc/grub.d/10_vanilla", []byte(bootTemplate), 0755); err != nil {
+
+	err = os.WriteFile("/partFuture/etc/grub.d/10_vanilla", []byte(bootTemplate), 0755)
+	if err != nil {
 		PrintVerbose("err:UpdateRootBoot: %s", err)
 		return err
 	}
 
 	PrintVerbose("step:  WriteFile present")
-	if err := os.WriteFile("/etc/grub.d/10_vanilla", []byte(bootTemplate), 0755); err != nil {
+
+	err = os.WriteFile("/etc/grub.d/10_vanilla", []byte(bootTemplate), 0755)
+	if err != nil {
 		PrintVerbose("err:UpdateRootBoot: %s", err)
 		return err
 	}
 
 	PrintVerbose("step:  Remove unwanted grub files in future")
+
 	for _, file := range unwanted {
 		os.Remove("/partFuture/etc/grub.d/" + file)
 	}
 
 	PrintVerbose("step:  Remove unwanted grub files in present")
+
 	for _, file := range unwanted {
 		os.Remove("/etc/grub.d/" + file)
 	}
 
 	PrintVerbose("step:  switchBootDefault")
+
 	next := "0"
-	if next, err = switchBootDefault(presentLabel); err != nil {
+
+	next, err = switchBootDefault(presentLabel)
+	if err != nil {
 		return err
 	}
 
 	PrintVerbose("step:  updateGrubConfig")
-	if err := updateGrubConfig(); err != nil {
+
+	err = updateGrubConfig()
+	if err != nil {
 		return err
 	}
 
 	PrintVerbose("step:  verifyGrubConfig")
-	if err := verifyGrubConfig(next); err != nil {
+
+	err = verifyGrubConfig(next)
+	if err != nil {
 		return err
 	}
 
@@ -500,18 +542,21 @@ export linux_gfx_mode
 // UpdateFsTab updates the fstab file to reflect the new root partition.
 func UpdateFsTab() error {
 	PrintVerbose("step:  GetPresentRootUUID")
+
 	presentUUID, err := GetPresentRootUUID()
 	if err != nil {
 		return err
 	}
 
 	PrintVerbose("step:  GetFutureRootUUID")
+
 	futureUUID, err := GetFutureRootUUID()
 	if err != nil {
 		return err
 	}
 
 	PrintVerbose("step:  ReadFile present")
+
 	fstab, err := os.ReadFile("/etc/fstab")
 	if err != nil {
 		PrintVerbose("err:updateFsTab: %s", err)
@@ -519,10 +564,12 @@ func UpdateFsTab() error {
 	}
 
 	PrintVerbose("step:  ReplaceAll future")
+
 	fstabFuture := fstab
 	fstabFuture = bytes.ReplaceAll(fstabFuture, []byte(presentUUID), []byte(futureUUID))
 
 	PrintVerbose("step: Configure Bind Mounts") // those are needed since symlinked directories cause issues with flatpak and snap
+
 	bindMounts := []string{"/var", "/opt"}
 	for _, bindMount := range bindMounts {
 		if !strings.Contains(string(fstabFuture), bindMount) {
@@ -531,7 +578,9 @@ func UpdateFsTab() error {
 	}
 
 	PrintVerbose("step:  WriteFile future")
-	if err := os.WriteFile("/partFuture/etc/fstab", fstabFuture, 0644); err != nil {
+
+	err = os.WriteFile("/partFuture/etc/fstab", fstabFuture, 0644)
+	if err != nil {
 		PrintVerbose("err:updateFsTab: %s", err)
 		return err
 	}
@@ -558,6 +607,7 @@ func getKernelVersion(state string) (string, error) {
 	}
 
 	var versions []string
+
 	for _, file := range files {
 		if file.IsDir() {
 			versions = append(versions, file.Name())
@@ -566,6 +616,7 @@ func getKernelVersion(state string) (string, error) {
 
 	sort.Strings(versions)
 	res := versions[len(versions)-1]
+
 	return res, nil
 }
 
@@ -588,27 +639,34 @@ func switchBootDefault(presentLabel string) (next string, err error) {
 	}
 
 	var grubContent strings.Builder
-	line_modified := false
+
+	lineModified := false
 	scanner := bufio.NewScanner(file)
+
 	for scanner.Scan() {
 		line := scanner.Text()
+
 		if strings.HasPrefix(line, "GRUB_DEFAULT=") {
-			line_modified = true
+			lineModified = true
+
 			grubContent.WriteString(fmt.Sprintf("GRUB_DEFAULT=%s\n", newGrubDefault))
 		} else {
 			grubContent.WriteString(line + "\n")
 		}
 	}
-	if !line_modified {
+
+	if !lineModified {
 		grubContent.WriteString(fmt.Sprintf("GRUB_DEFAULT=%s\n", newGrubDefault))
 	}
 
-	if err := os.WriteFile("/etc/default/grub", []byte(grubContent.String()), 0644); err != nil {
+	err = os.WriteFile("/etc/default/grub", []byte(grubContent.String()), 0644)
+	if err != nil {
 		PrintVerbose("err:switchBootDefault: %s", err)
 		return "", err
 	}
 
-	if err := os.WriteFile("/partFuture/etc/default/grub", []byte(grubContent.String()), 0644); err != nil {
+	err = os.WriteFile("/partFuture/etc/default/grub", []byte(grubContent.String()), 0644)
+	if err != nil {
 		PrintVerbose("err:switchBootDefault: %s", err)
 		return "", err
 	}
@@ -634,7 +692,8 @@ func verifyGrubConfig(expected string) error {
 			grubCfg = bytes.ReplaceAll(grubCfg, []byte("set default=\"0\""), []byte("set default=\"1\""))
 		}
 
-		if err := os.WriteFile("/boot/grub/grub.cfg", grubCfg, 0644); err != nil {
+		err := os.WriteFile("/boot/grub/grub.cfg", grubCfg, 0644)
+		if err != nil {
 			PrintVerbose("err:verifyGrubConfig: %s", err)
 			return err
 		}
@@ -661,18 +720,22 @@ func updateGrubConfig() error {
 	}
 	for _, command := range commandList {
 		cmd := exec.Command(command[0], command[1:]...)
+
 		err := cmd.Run()
 		if err != nil {
 			if strings.Contains(cmd.String(), "efivars") {
 				continue // Ignore error, we are probably not on UEFI
 			}
+
 			PrintVerbose("err:updateGrubConfig (BindMount): %s", err)
 			PrintVerbose("err:updateGrubConfig (BindMount): command: %s", command)
+
 			return err
 		}
 	}
 
-	if err := exec.Command("grub-mkconfig", "-o", "/boot/grub/grub.cfg").Run(); err != nil {
+	err := exec.Command("grub-mkconfig", "-o", "/boot/grub/grub.cfg").Run()
+	if err != nil {
 		PrintVerbose("err:updateGrubConfig: %s", err)
 		return err
 	}
@@ -706,17 +769,19 @@ func GetFutureRootUUID() (string, error) {
 
 /* DoesSupportAB check if the current system supports A/B partitioning */
 func DoesSupportAB() bool {
-	var support bool = true
+	support := true
 
 	_, err := GetPresentRootDevice()
 	if err != nil {
 		PrintVerbose("err:DoesSupportAB: %s", err)
+
 		support = false
 	}
 
 	_, err = GetFutureRootDevice()
 	if err != nil {
 		PrintVerbose("err:DoesSupportAB: %s", err)
+
 		support = false
 	}
 
@@ -725,7 +790,8 @@ func DoesSupportAB() bool {
 
 /* SetMutablePath sets the i attribute of the given path to mutable. */
 func SetMutablePath(path string) error {
-	if err := exec.Command("chattr", "-i", path).Run(); err != nil {
+	err := exec.Command("chattr", "-i", path).Run()
+	if err != nil {
 		PrintVerbose("err:SetMutablePath: %s", err)
 		return err
 	}
@@ -735,7 +801,8 @@ func SetMutablePath(path string) error {
 
 /* SetImmutablePath sets the i attribute of the given path to immutable. */
 func SetImmutablePath(path string) error {
-	if err := exec.Command("chattr", "+i", path).Run(); err != nil {
+	err := exec.Command("chattr", "+i", path).Run()
+	if err != nil {
 		PrintVerbose("err:SetImmutablePath: %s", err)
 		return err
 	}
@@ -758,48 +825,50 @@ func getGRUBMarkedRoot(state string) (string, error) {
 		}
 	}
 
-	return "", errors.New(fmt.Sprintf("No partition found for state %s", state))
+	return "", fmt.Errorf("No partition found for state %s", state)
 }
 
 // Rollback switches back to the previous root.
 func Rollback() error {
 	// Root marked as "current" by ABroot
-	current_root, err := getGRUBMarkedRoot("current")
+	currentRoot, err := getGRUBMarkedRoot("current")
 	if err != nil {
 		return err
 	}
 
 	// Root we're booted into
-	currently_booted_root, err := getCurrentRootLabel()
+	currentlyBootedRoot, err := getCurrentRootLabel()
 	if err != nil {
 		return err
 	}
 
-	var previous_root string
-	if current_root == "a" {
-		previous_root = "b"
+	var previousRoot string
+	if currentRoot == "a" {
+		previousRoot = "b"
 	} else {
-		previous_root = "a"
+		previousRoot = "a"
 	}
 
 	bold := cmdr.Bold.Sprint
 	red := cmdr.Red
 	green := cmdr.Green
 
-	var currently_booted_root_colored string
-	var rollback_kargs string
-	if current_root == currently_booted_root {
-		rollback_kargs, err = GetFutureKargs()
+	var currentlyBootedRootColored, rollbackKargs string
+
+	if currentRoot == currentlyBootedRoot {
+		rollbackKargs, err = GetFutureKargs()
 		if err != nil {
 			return err
 		}
-		currently_booted_root_colored = red(strings.ToUpper(currently_booted_root))
+
+		currentlyBootedRootColored = red(strings.ToUpper(currentlyBootedRoot))
 	} else {
-		rollback_kargs, err = GetCurrentKargs()
+		rollbackKargs, err = GetCurrentKargs()
 		if err != nil {
 			return err
 		}
-		currently_booted_root_colored = green(strings.ToUpper(currently_booted_root))
+
+		currentlyBootedRootColored = green(strings.ToUpper(currentlyBootedRoot))
 	}
 
 	message := fmt.Sprintf(`
@@ -808,10 +877,10 @@ Your "present" partition is %s
 
 This command will make %s the present partition again. Any changes made to %s will be lost.
 Continue?`,
-		bold(currently_booted_root_colored),
-		bold(red(strings.ToUpper(current_root))),
-		bold(green(strings.ToUpper(previous_root))),
-		bold(red(strings.ToUpper(current_root))),
+		bold(currentlyBootedRootColored),
+		bold(red(strings.ToUpper(currentRoot))),
+		bold(green(strings.ToUpper(previousRoot))),
+		bold(red(strings.ToUpper(currentRoot))),
 	)
 
 	confirmation, err := cmdr.Confirm.Show(message)
@@ -820,7 +889,7 @@ Continue?`,
 	}
 
 	if confirmation {
-		UpdateRootBoot(false, rollback_kargs)
+		UpdateRootBoot(false, rollbackKargs)
 		cmdr.Success.Println("Rollback complete. Reboot your system to apply changes.")
 	}
 

--- a/core/utils.go
+++ b/core/utils.go
@@ -14,7 +14,8 @@ func init() {
 	}
 
 	if _, err := os.Stat(abrootDir); os.IsNotExist(err) {
-		if err := os.Mkdir(abrootDir, 0755); err != nil {
+		err := os.Mkdir(abrootDir, 0755)
+		if err != nil {
 			fmt.Println(err)
 			os.Exit(1)
 		}

--- a/main.go
+++ b/main.go
@@ -16,7 +16,6 @@ var fs embed.FS
 var abroot *cmdr.App
 
 func main() {
-
 	abroot = cmd.New(Version, fs)
 
 	// root command
@@ -49,9 +48,7 @@ func main() {
 	err := abroot.Run()
 	if err != nil {
 		cmdr.Error.Println(err)
-
 	}
-
 }
 
 /*


### PR DESCRIPTION
If `apt` detects the presence of `/run/dbus/system_bus_socket` file, it tries to start systemd units during package installation.

This leads to problems installing softwares like snapd, virtualbox and many others.

Remove the `/run` mountpoint, as it's not needed for the abroot functionality.

Also do some chores, improve formatting, var naming, remove err variable shadowing

Closes https://github.com/Vanilla-OS/os/issues/108