### PR TITLE
Check if system is UEFI before mounting EFI

### DIFF
--- a/core/overlayfs.go
+++ b/core/overlayfs.go
@@ -101,7 +101,10 @@ func NewOverlayFS(lowers []string) error {
 		}
 	}
 
-	bindFromBootPaths := []string{"boot", "boot/efi"}
+	bindFromBootPaths := []string{"boot"}
+	if IsSystemUEFI() {
+		bindFromBootPaths = append(bindFromBootPaths, "boot/efi")
+	}
 	for _, path := range bindFromBootPaths {
 		err := os.MkdirAll(overlayfsPath+"/"+path, 0755)
 		if err != nil {

--- a/core/utils.go
+++ b/core/utils.go
@@ -34,6 +34,20 @@ func RootCheck(display bool) bool {
 	return true
 }
 
+func IsSystemUEFI() bool {
+	_, err := os.Stat("/sys/firmware/efi")
+	if os.IsNotExist(err) {
+		return false
+	}
+
+	if err != nil {
+		fmt.Printf("Error checking for EFI files: %s", err)
+		os.Exit(1)
+	}
+
+	return true
+}
+
 func AskConfirmation(s string) bool {
 	var response string
 


### PR DESCRIPTION
This PR makes ABroot check if the system is UEFI before trying to bind an EFI partition