### PR TITLE
Fixes for image-operations

### DIFF
--- a/core/oci.go
+++ b/core/oci.go
@@ -20,6 +20,7 @@ import (
 	"path/filepath"
 
 	"github.com/containers/buildah"
+	cstypes "github.com/containers/storage/types"
 	"github.com/vanilla-os/abroot/settings"
 	"github.com/vanilla-os/prometheus"
 )
@@ -178,7 +179,7 @@ func DeleteImageForRoot(root string) error {
 	}
 
 	_, err = pt.Store.DeleteImage(image, true)
-	if err != nil {
+	if err != nil && err != cstypes.ErrNotAnImage {
 		PrintVerbose("DeleteImageForRoot:err(3): %s", err)
 		return err
 	}

--- a/core/oci.go
+++ b/core/oci.go
@@ -147,7 +147,7 @@ func FindImageWithLabel(key, value string) (string, error) {
 	return "", nil
 }
 
-// DeleteImageForRoot retrieves the image created for the provided root ("vos-a"|"vos-b")
+// RetrieveImageForRoot retrieves the image created for the provided root ("vos-a"|"vos-b")
 func RetrieveImageForRoot(root string) (string, error) {
 	PrintVerbose("ApplyInImageForRoot: running...")
 

--- a/core/system.go
+++ b/core/system.go
@@ -453,6 +453,10 @@ func (s *ABSystem) RunOperation(operation ABSystemOperation) error {
 			PrintVerbose("ABSystemRunOperation:err(3.3): %s", err)
 			return err
 		}
+		// Handle case where an image for the current root may not exist in storage
+		if imageName == "" {
+			imageName = settings.Cnf.FullImageName
+		}
 	} else {
 		imageName = strings.Split(settings.Cnf.FullImageName, ":")[0] + "@" + imageDigest
 		labels["ABRoot.BaseImageDigest"] = s.CurImage.Digest


### PR DESCRIPTION
This PR fixes two issues with applying image operations:

- Handle error when trying to delete an image that doesn't exist
- Handle error when applying packages when the image for the current root doesn't exist