### PR TITLE
Fix: Broken locales after installation

### DIFF
--- a/core/integrity.go
+++ b/core/integrity.go
@@ -37,6 +37,7 @@ func NewIntegrityCheck(root ABRootPartition, repair bool) (*IntegrityCheck, erro
 		"/var/lib/abroot/etc",
 		fmt.Sprintf("%s-work", root.Label),
 	)
+	etcLocalePath := filepath.Join("/var/lib/abroot/etc", root.Label, "locales")
 	ic := &IntegrityCheck{
 		rootPath:   root.Partition.MountPoint,
 		systemPath: systemPath,
@@ -70,6 +71,7 @@ func NewIntegrityCheck(root ABRootPartition, repair bool) (*IntegrityCheck, erro
 		etcPaths: []string{
 			etcPath,
 			etcWorkPath,
+			etcLocalePath,
 		},
 	}
 

--- a/core/system.go
+++ b/core/system.go
@@ -391,6 +391,7 @@ mount -t overlay overlay -o lowerdir=/.system/etc,upperdir=/var/lib/abroot/etc/%
 mount -o bind /var/home /home
 mount -o bind /var/opt /opt
 mount -o bind,ro /.system/usr /usr
+mount -o bind /var/lib/abroot/etc/%s/locales /usr/lib/locale
 `
 	mountExtCmd := ""
 	if strings.HasPrefix(s.RootM.VarPartition.Device, "luks-") {
@@ -399,7 +400,7 @@ mount -o bind,ro /.system/usr /usr
 	} else {
 		mountExtCmd = fmt.Sprintf("-U %s", s.RootM.VarPartition.Uuid)
 	}
-	mountpoints := fmt.Sprintf(template, mountExtCmd, root.Label, root.Label)
+	mountpoints := fmt.Sprintf(template, mountExtCmd, root.Label, root.Label, root.Label)
 
 	err := os.WriteFile(rootPath+MountScriptPath, []byte(mountpoints), 0755)
 	if err != nil {


### PR DESCRIPTION
Related PR: https://github.com/Vanilla-OS/vanilla-installer/pull/270 
This PR adds the mountpoint to the new locales directory in ABroot, as well as an the integrity check for the directory.