### PR TITLE
Fix account service race

### DIFF
--- a/core/system.go
+++ b/core/system.go
@@ -469,7 +469,7 @@ ExecStart=%s
 		return err
 	}
 
-	err = os.Symlink(rootPath+MountUnitDir+MountUnitFile, rootPath+fmt.Sprintf(SystemDTargetDir, depTarget)+MountUnitFile)
+	err = os.Symlink(".."+MountUnitFile, rootPath+fmt.Sprintf(SystemDTargetDir, depTarget)+MountUnitFile)
 	if err != nil {
 		PrintVerbose("ABSystem.GenerateMountpointsSystemDUnit:err(4): %s", err)
 		return err

--- a/core/system.go
+++ b/core/system.go
@@ -436,6 +436,7 @@ func (s *ABSystem) GenerateMountpointsSystemDUnit(rootPath string, root ABRootPa
 Description=Mount partitions
 Requires=%s.target
 After=%s.target
+Before=nss-user-lookup.target
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
The accounts daemon service sometimes runs, while var is not mounted yet. This causes the service to ignore the contents of `/var/lib/AccountsService/users/` and later delete the contents. This causes gdm to sometimes forget the user session and will default back to the first setup session. 

![Screenshot from 2023-12-01 14-56-53](https://github.com/Vanilla-OS/ABRoot/assets/44101694/6a0540f8-27d3-41ce-aaae-c5a5e0177fe2)

This PR tells systemd to reach nss-user-lookup.target after the abroot mount service. Since accounts daemon depends on nss-user-lookup.target, it will always start after the abroot-mount service.

![Screenshot from 2023-12-01 13-58-09](https://github.com/Vanilla-OS/ABRoot/assets/44101694/c29f52a3-6339-4f92-b908-ef01d7eea203)
