### PR TITLE
feat:[close #159] Systemd mount units

### DIFF
--- a/core/disk-manager.go
+++ b/core/disk-manager.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"strings"
 	"syscall"
 )
 
@@ -209,4 +210,9 @@ func (p *Partition) Unmount() error {
 // Returns whether the partition is a device-mapper virtual partition
 func (p *Partition) IsDevMapper() bool {
 	return p.Parent != nil
+}
+
+// IsEncrypted returns whether the partition is encrypted
+func (p *Partition) IsEncrypted() bool {
+	return strings.HasPrefix(p.Device, "luks-")
 }


### PR DESCRIPTION
Using systemd mount units instead of a mount script together with a systemd service has a couple of benefits:
- slightly faster boot since some mounts can be run in parallel
- it's a more standard way of doing things
- it's easier to manage more complex dependencies between mount points

The dependency between mounts with this implementation looks like this:
![systemd_diagram](https://github.com/Vanilla-OS/ABRoot/assets/44101694/e6566705-7fe2-4fb0-a2ed-dbb83c3b0be0)

The reason we can't do this all in fstab is because you can't easily tell systemd to mount  for example /home from /var/home after /var is mounted.

The question is: If we already use systemd mount units, it might be cleaner to put everything into mount units and not just the bind and overlay mounts. (The behavior would be identical since systemd just generates the mount units anyway from fstab) 

Additionally, currently, the system will still try to boot even if a mount point fails, should this be changed so that systemd has to boot into recovery if a mount fails? 

Also, if you want to test this, you can currently use this build: https://github.com/taukakao/ABRoot/releases/tag/systemdmount

Things that still need to be done:
- [x] decide if we should move everything from fstab to mount units (no, not worth it)
- [x] decide if the boot should fail on one failed mount point (no, the system can display an error in the future if it failed)
- [x] remove workflow changes
- [x] rebase and squash
- [x] also reflect these changes in the installer