### PR TITLE
feat[close #24] Add --dry-run option

### DIFF
--- a/cmd/pkg.go
+++ b/cmd/pkg.go
@@ -33,6 +33,13 @@ func NewPkgCommand() *cmdr.Command {
 		pkg,
 	)
 
+	cmd.WithBoolFlag(
+		cmdr.NewBoolFlag(
+			"dry-run",
+			"d",
+			abroot.Trans("pkg.dryRunFlag"),
+			false))
+
 	cmd.Args = cobra.MinimumNArgs(1)
 	cmd.ValidArgs = validPkgArgs
 	cmd.Example = "abroot pkg add <pkg>"
@@ -44,6 +51,12 @@ func pkg(cmd *cobra.Command, args []string) error {
 	if !core.RootCheck(false) {
 		cmdr.Error.Println(abroot.Trans("pkg.rootRequired"))
 		return nil
+	}
+
+	dryRun, err := cmd.Flags().GetBool("dry-run")
+	if err != nil {
+		cmdr.Error.Println(err)
+		return err
 	}
 
 	pkgM := core.NewPackageManager(false)
@@ -95,7 +108,11 @@ func pkg(cmd *cobra.Command, args []string) error {
 			return err
 		}
 
-		err = aBsys.RunOperation(core.APPLY)
+		if dryRun {
+			err = aBsys.RunOperation(core.DRY_RUN_APPLY)
+		} else {
+			err = aBsys.RunOperation(core.APPLY)
+		}
 		if err != nil {
 			cmdr.Error.Printf(abroot.Trans("pkg.applyFailed"), err)
 			return err

--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -42,6 +42,13 @@ func NewUpgradeCommand() *cmdr.Command {
 
 	cmd.WithBoolFlag(
 		cmdr.NewBoolFlag(
+			"dry-run",
+			"d",
+			abroot.Trans("upgrade.dryRunFlag"),
+			false))
+
+	cmd.WithBoolFlag(
+		cmdr.NewBoolFlag(
 			"force",
 			"f",
 			abroot.Trans("upgrade.forceFlag"),
@@ -54,6 +61,12 @@ func NewUpgradeCommand() *cmdr.Command {
 
 func upgrade(cmd *cobra.Command, args []string) error {
 	checkOnly, err := cmd.Flags().GetBool("check-only")
+	if err != nil {
+		cmdr.Error.Println(err)
+		return err
+	}
+
+	dryRun, err := cmd.Flags().GetBool("dry-run")
 	if err != nil {
 		cmdr.Error.Println(err)
 		return err
@@ -121,6 +134,8 @@ func upgrade(cmd *cobra.Command, args []string) error {
 	var operation core.ABSystemOperation
 	if force {
 		operation = core.FORCE_UPGRADE
+	} else if dryRun {
+		operation = core.DRY_RUN_UPGRADE
 	} else {
 		operation = core.UPGRADE
 	}

--- a/core/system.go
+++ b/core/system.go
@@ -617,13 +617,6 @@ func (s *ABSystem) RunOperation(operation ABSystemOperation) error {
 		labels["ABRoot.BaseImageDigest"] = imageDigest
 	}
 
-	// Delete old image
-	err = DeleteImageForRoot(futurePartition.Label)
-	if err != nil {
-		PrintVerbose("ABSystemRunOperation:err(3.4): %s", err)
-		return err
-	}
-
 	imageRecipe := NewImageRecipe(
 		imageName,
 		labels,
@@ -716,6 +709,20 @@ func (s *ABSystem) RunOperation(operation ABSystemOperation) error {
 		return err
 	}
 
+	// Stage (dry): If dry-run, exit here before writing to disk
+	// ------------------------------------------------
+	if operation == DRY_RUN_UPGRADE || operation == DRY_RUN_APPLY {
+		PrintVerbose("ABSystem.RunOperation: dry-run completed")
+		return nil
+	}
+
+	// Stage 6.3: Delete old image
+	err = DeleteImageForRoot(futurePartition.Label)
+	if err != nil {
+		PrintVerbose("ABSystemRunOperation:err(6.3): %s", err)
+		return err
+	}
+
 	// Stage 7: Update the bootloader
 	// ------------------------------------------------
 	PrintVerbose("[Stage 7] -------- ABSystemRunOperation")
@@ -796,13 +803,6 @@ func (s *ABSystem) RunOperation(operation ABSystemOperation) error {
 	if err != nil {
 		PrintVerbose("ABSystem.RunOperation:err(7.6): %s", err)
 		return err
-	}
-
-	// Stage (dry): If dry-run, exit here before writing to disk
-	// ------------------------------------------------
-	if operation == DRY_RUN_UPGRADE || operation == DRY_RUN_APPLY {
-		PrintVerbose("ABSystem.RunOperation: dry-run completed")
-		return nil
 	}
 
 	// Stage 8: Sync /etc

--- a/core/system.go
+++ b/core/system.go
@@ -41,9 +41,11 @@ type QueuedFunction struct {
 }
 
 const (
-	UPGRADE       = "upgrade"
-	FORCE_UPGRADE = "force-upgrade"
-	APPLY         = "package-apply"
+	UPGRADE         = "upgrade"
+	FORCE_UPGRADE   = "force-upgrade"
+	DRY_RUN_UPGRADE = "dry-run-upgrade"
+	APPLY           = "package-apply"
+	DRY_RUN_APPLY   = "dry-run-package-apply"
 )
 
 const (
@@ -595,7 +597,7 @@ func (s *ABSystem) RunOperation(operation ABSystemOperation) error {
 	content := `RUN ` + pkgsFinal
 
 	var imageName string
-	if operation == APPLY {
+	if operation == APPLY || operation == DRY_RUN_APPLY {
 		presentPartition, err := s.RootM.GetPresent()
 		if err != nil {
 			PrintVerbose("ABSystemRunOperation:err(3.2): %s", err)
@@ -794,6 +796,13 @@ func (s *ABSystem) RunOperation(operation ABSystemOperation) error {
 	if err != nil {
 		PrintVerbose("ABSystem.RunOperation:err(7.6): %s", err)
 		return err
+	}
+
+	// Stage (dry): If dry-run, exit here before writing to disk
+	// ------------------------------------------------
+	if operation == DRY_RUN_UPGRADE || operation == DRY_RUN_APPLY {
+		PrintVerbose("ABSystem.RunOperation: dry-run completed")
+		return nil
 	}
 
 	// Stage 8: Sync /etc

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -30,6 +30,7 @@ pkg:
   applyFailed: "Apply command failed: %s\n"
   removedMsg: "Package(s) %s removed.\n"
   listMsg: "Added packages:\n%s\nRemoved packages:\n%s\n"
+  dryRunFlag: "perform a dry run of the operation"
 
 status:
   use: "status"
@@ -77,6 +78,7 @@ upgrade:
   packageUpdateAvailable: "There are %d package updates."
   noUpdateAvailable: "No update available."
   checkOnlyFlag: "check for updates but do not apply them"
+  dryRunFlag: "perform a dry run of the operation"
   added: "Added"
   upgraded: "Upgraded"
   downgraded: "Downgraded"


### PR DESCRIPTION
close #24

I am unable to test due a problem with ABRoot which afflict my installation since weeks:
```
  ERROR   building at STEP "LABEL maintainer 'Generated by ABRoot'": error decoding response from copier subprocess: invalid character '(' looking for beginning of value
Error: building at STEP "LABEL maintainer 'Generated by ABRoot'": error decoding response from copier subprocess: invalid character '(' looking for beginning of value
```