### PR TITLE
feat: JSON output for upgrade check

### DIFF
--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -97,9 +97,11 @@ func upgrade(cmd *cobra.Command, args []string) error {
 			if err != nil {
 				return err
 			}
-			err = renderPackageDiff(sysAdded, sysUpgraded, sysDowngraded, sysRemoved)
-			if err != nil {
-				return err
+			if !raw {
+				err = renderPackageDiff(sysAdded, sysUpgraded, sysDowngraded, sysRemoved)
+				if err != nil {
+					return err
+				}
 			}
 		} else if !raw {
 			cmdr.Info.Println(abroot.Trans("upgrade.noUpdateAvailable"))

--- a/core/package-diff.go
+++ b/core/package-diff.go
@@ -52,10 +52,17 @@ func BaseImagePackageDiff(currentDigest, newDigest string) (
 		PrintVerbose("PackageDiff.BaseImagePackageDiff(1):err: %s", err)
 		return
 	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		PrintVerbose("PackageDiff.BaseImagePackageDiff(2):err: received non-ok status %s", resp.Status)
+		err = fmt.Errorf("package diff server returned non-OK status %s", resp.Status)
+		return
+	}
 
 	contents, err := io.ReadAll(resp.Body)
 	if err != nil {
-		PrintVerbose("PackageDiff.BaseImagePackageDiff(2):err: %s", err)
+		PrintVerbose("PackageDiff.BaseImagePackageDiff(3):err: %s", err)
 		return
 	}
 
@@ -64,7 +71,7 @@ func BaseImagePackageDiff(currentDigest, newDigest string) (
 	}{}
 	err = json.Unmarshal(contents, &pkgDiff)
 	if err != nil {
-		PrintVerbose("PackageDiff.BaseImagePackageDiff(3):err: %s", err)
+		PrintVerbose("PackageDiff.BaseImagePackageDiff(4):err: %s", err)
 		return
 	}
 


### PR DESCRIPTION
This PR adds a json output for the command `abroot upgrade -c` when the user specifies the environment variable `ABROOT_JSON_OUTPUT`. This can be useful by tools such as VSO in order to get a machine-readable package diff.

Slightly unrelated but I also added a check for handling non-OK HTTP status codes when querying the Differ API, whereas before it would crash ABRoot,