### PR TITLE
fix [#198]: set var correctly in fstab when not lvm

### DIFF
--- a/core/system.go
+++ b/core/system.go
@@ -367,7 +367,7 @@ UUID=%s  /  %s  defaults  0  0
 	if s.RootM.VarPartition.IsDevMapper() {
 		varSource = fmt.Sprintf("/dev/mapper/%s", s.RootM.VarPartition.Device)
 	} else {
-		varSource = fmt.Sprintf("-U %s", s.RootM.VarPartition.Uuid)
+		varSource = fmt.Sprintf("UUID=%s", s.RootM.VarPartition.Uuid)
 	}
 
 	fstab := fmt.Sprintf(


### PR DESCRIPTION
The -U flag was incorrectly copied from the old process of mounting with the mount command. That does not work with fstab.

Fixes #198 