### PR TITLE
add checksum check to image copy

### DIFF
--- a/core/oci.go
+++ b/core/oci.go
@@ -102,7 +102,7 @@ func OciExportRootFs(buildImageName string, imageRecipe *ImageRecipe, transDir s
 	}
 
 	// copy mount dir contents to dest
-	err = rsyncCmd(mountDir+"/", dest, []string{"--delete"}, false)
+	err = rsyncCmd(mountDir+"/", dest, []string{"--delete", "--checksum"}, false)
 	if err != nil {
 		PrintVerboseErr("OciExportRootFs", 9, err)
 		return err


### PR DESCRIPTION
The old behaviour skipped files that had equal modification time and size. This scenario seemed unlikely but testing showed it isn't.

This was discovered because fsguard would detect the hashes of some files differed from the desktop image. 

Comparing hashes sadly takes a bit longer than modification time and size so this will slow down abroot a bit depending on the read speed of the drive being used.

Tested in a VM and it works as expected.