### PR TITLE
fix: image's etc changes not being applied

### DIFF
--- a/core/diff.go
+++ b/core/diff.go
@@ -90,7 +90,7 @@ func WriteDiff(destFile string, diffLines []byte) error {
 		return nil // no changes to apply
 	}
 
-	cmd := exec.Command("patch", "-R", destFile)
+	cmd := exec.Command("patch", "--verbose", destFile)
 	cmd.Stdin = bytes.NewReader(diffLines)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr


### PR DESCRIPTION
Should fix: https://github.com/Vanilla-Kattleya/plasma-image/issues/10

The problem I was facing is the `sddm` user not being added to `/var/lib/abroot/etc/vos-b/passwd`. I did the process manually by diffing and patching both `passwd` files, then I found the changes were not being applied due to the `-R` flag being present, here the manpage:

```text
  -R  --reverse  Assume patches were created with old and new files swapped.
```

by removing the flag, the changes got merged to `/var/lib/abroot/etc/vos-b/passwd`. Not sure if this ever worked before, I did some tests at the time but I forgot to document why I added the `-R` flag.


I need feedback and another test, perhaps using a different image, I am using the KDE image) on this before merging. The binary for testing will be available as an artifact once https://github.com/Vanilla-OS/ABRoot/actions/runs/7972020941 completes.