### PR TITLE
fix [close #171]: Make grub configurable

### DIFF
--- a/core/system.go
+++ b/core/system.go
@@ -832,6 +832,8 @@ func (s *ABSystem) RunOperation(operation ABSystemOperation) error {
 		systemNew,
 		partFuture.Partition.Uuid,
 		partFuture.Partition.Device,
+		true,
+		filepath.Join("/var/lib/abroot/etc", partPresent.Label),
 	)
 	if err != nil {
 		PrintVerboseErr("ABSystem.RunOperation", 7, err)

--- a/tests/chroot_test.go
+++ b/tests/chroot_test.go
@@ -56,7 +56,7 @@ func TestChroot(t *testing.T) {
 	}
 
 	// chroot setup
-	chroot, err := core.NewChroot(chrootPath, chrootUuid, chrootDevice)
+	chroot, err := core.NewChroot(chrootPath, chrootUuid, chrootDevice, false, "")
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
The grub.cfg should not be hard-coded into abroot. 

This PR uses the generated grub config file and adds the abroot boot entry.

This PR also mounts the user changes to /etc inside the chroot. This allows for customizing grub with for example /etc/default/grub.

This depends on https://github.com/Vanilla-OS/core-image/pull/34
It needs to be merged before it but at around the same time to avoid conflicts. 