### PR TITLE
feat: Improve status cmd output

### DIFF
--- a/core/system.go
+++ b/core/system.go
@@ -296,7 +296,7 @@ UUID=%s  /  %s  defaults  0  0
 		varSource,
 	)
 
-	err := os.WriteFile(filepath.Join(rootPath, "/etc/fstab"), []byte(fstab), 0644)
+	err := os.WriteFile(filepath.Join(rootPath, "/etc/fstab"), []byte(fstab), 0o644)
 	if err != nil {
 		PrintVerboseErr("ABSystem.GenerateFstab", 0, err)
 		return err
@@ -347,7 +347,7 @@ func (s *ABSystem) GenerateCrypttab(rootPath string) error {
 		crypttabContent += fmtEntry + "\n"
 	}
 
-	err := os.WriteFile(rootPath+"/etc/crypttab", []byte(crypttabContent), 0644)
+	err := os.WriteFile(rootPath+"/etc/crypttab", []byte(crypttabContent), 0o644)
 	if err != nil {
 		PrintVerboseErr("ABSystem.GenerateCrypttab", 3, err)
 		return err
@@ -404,9 +404,9 @@ Options=%s
 			PrintVerboseErr("ABSystem.GenerateSystemdUnits", 0, "failed to determine escaped path", err)
 			return err
 		}
-		mountUnitFile := "/" + strings.Replace(string(out), "\n", "", -1) + ".mount"
+		mountUnitFile := "/" + strings.ReplaceAll(string(out), "\n", "") + ".mount"
 
-		err = os.WriteFile(filepath.Join(rootPath, mountUnitDir, mountUnitFile), []byte(unit), 0644)
+		err = os.WriteFile(filepath.Join(rootPath, mountUnitDir, mountUnitFile), []byte(unit), 0o644)
 		if err != nil {
 			PrintVerboseErr("ABSystem.GenerateSystemdUnits", 1, err)
 			return err
@@ -414,7 +414,7 @@ Options=%s
 
 		const targetWants string = "/local-fs.target.wants"
 
-		err = os.MkdirAll(filepath.Join(rootPath, mountUnitDir, targetWants), 0755)
+		err = os.MkdirAll(filepath.Join(rootPath, mountUnitDir, targetWants), 0o755)
 		if err != nil {
 			PrintVerboseErr("ABSystem.GenerateSystemdUnits", 2, err)
 			return err
@@ -642,7 +642,7 @@ func (s *ABSystem) RunOperation(operation ABSystemOperation) error {
 			PrintVerboseErr("ABSystemRunOperation", 4, err)
 			return err
 		}
-		err = os.MkdirAll(systemOld, 0755)
+		err = os.MkdirAll(systemOld, 0o755)
 		if err != nil {
 			PrintVerboseErr("ABSystemRunOperation", 4.1, err)
 			return err
@@ -878,7 +878,7 @@ func (s *ABSystem) RunOperation(operation ABSystemOperation) error {
 
 	uuid := uuid.New().String()
 	tmpBootMount := filepath.Join("/tmp", uuid)
-	err = os.Mkdir(tmpBootMount, 0755)
+	err = os.Mkdir(tmpBootMount, 0o755)
 	if err != nil {
 		PrintVerboseErr("ABSystem.RunOperation", 9, err)
 		return err
@@ -967,7 +967,7 @@ func (s *ABSystem) RunOperation(operation ABSystemOperation) error {
 			}
 
 			replacer := strings.NewReplacer(replacerPairs...)
-			os.WriteFile(grubCfgFuture, []byte(replacer.Replace(string(grubCfgContents))), 0644)
+			os.WriteFile(grubCfgFuture, []byte(replacer.Replace(string(grubCfgContents))), 0o644)
 		}
 
 		err = AtomicSwap(grubCfgCurrent, grubCfgFuture)
@@ -1004,7 +1004,7 @@ func (s *ABSystem) Rollback(checkOnly bool) (response ABRollbackResponse, err er
 
 	uuid := uuid.New().String()
 	tmpBootMount := filepath.Join("/tmp", uuid)
-	err = os.Mkdir(tmpBootMount, 0755)
+	err = os.Mkdir(tmpBootMount, 0o755)
 	if err != nil {
 		PrintVerboseErr("ABSystem.Rollback", 2, err)
 		return ROLLBACK_FAILED, err
@@ -1073,7 +1073,7 @@ func (s *ABSystem) Rollback(checkOnly bool) (response ABRollbackResponse, err er
 		}
 
 		replacer := strings.NewReplacer(replacerPairs...)
-		os.WriteFile(grubCfgFuture, []byte(replacer.Replace(string(grubCfgContents))), 0644)
+		os.WriteFile(grubCfgFuture, []byte(replacer.Replace(string(grubCfgContents))), 0o644)
 	}
 
 	err = AtomicSwap(grubCfgCurrent, grubCfgFuture)

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -60,30 +60,28 @@ status:
   jsonFlag: "show output in JSON format"
   dumpFlag: "dump the ABRoot status to an archive"
   rootRequired: "You must be root to run this command."
-  infoMsg: |
-    ABRoot Partitions:
-      - Present: %s ◄
-      - Future: %s
-
-    Loaded Configuration: %s
-
-    Device Specifications:
-      - CPU: %s
-      - GPU:%s
-      - Memory: %s
-
-    ABImage:
-      - Digest: %s
-      - Timestamp: %s
-      - Image: %s
-
-    Kernel Arguments: %s
-
-    Packages:
-      - Added: %s
-      - Removed: %s
-      - Unstaged: %s%s
-  infoMsgAgreementStatus: "\nPackage agreement: %t"
+  partitions:
+    title: "ABRoot Partitions:"
+    present: "Present: %s%s"
+    future: "Future: %s%s"
+  loadedConfig: "Loaded Configuration:"
+  specs:
+    title: "Device Specifications:"
+    cpu: "CPU: %s"
+    gpu: "GPU: %s"
+    memory: "Memory: %s"
+  abimage:
+    title: "ABImage:"
+    digest: "Digest: %s"
+    timestamp: "Timestamp: %s"
+    image: "Image: %s"
+  kargs: "Kernel Arguments: %s"
+  packages:
+    title: "Packages:"
+    added: "Added: %s"
+    removed: "Removed: %s"
+    unstaged: "Unstaged: %s%s"
+  agreementStatus: "Package agreement:"
   unstagedFoundMsg: "\n\t\tThere are %d unstaged packages. Please run 'abroot pkg
     apply' to apply them."
   dumpMsg: "Dumped ABRoot status to %s\n"


### PR DESCRIPTION
This PR improves the `abroot status` output by using several pterm (a.k.a Orchid lib) elements instead of a single Info command.

Preview:
![image](https://github.com/Vanilla-OS/ABRoot/assets/48367298/20a8e57e-73f8-4ef0-a7e4-33ecc5654e14)

I thought about adding some color, but I'm out of ideas on how to do that without making it look too colorful.

Ideas are appreciated.