### PR TITLE
Add accept header for registry

### DIFF
--- a/core/registry.go
+++ b/core/registry.go
@@ -125,6 +125,7 @@ func (r *Registry) GetManifest(token string) (*Manifest, error) {
 
 	req.Header.Set("User-Agent", "abroot")
 	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token))
+	req.Header.Set("Accept", "application/vnd.oci.image.manifest.v1+json")
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
@@ -150,6 +151,10 @@ func (r *Registry) GetManifest(token string) (*Manifest, error) {
 	digest := resp.Header.Get("Docker-Content-Digest")
 
 	// we need to parse the layers to get the digests
+	if m["layers"] == nil {
+		PrintVerboseErr("Registry.GetManifest", 4, err)
+		return nil, fmt.Errorf("Manifest does not contain layer property")
+	}
 	layers := m["layers"].([]interface{})
 	var layerDigests []string
 	for _, layer := range layers {


### PR DESCRIPTION
ghcr requires an accept header to be set to retrieve information of images.