### PR TITLE
fix [#286]: removes locale bind mount

### DIFF
--- a/core/integrity.go
+++ b/core/integrity.go
@@ -38,7 +38,6 @@ func NewIntegrityCheck(root ABRootPartition, repair bool) (*IntegrityCheck, erro
 		"/var/lib/abroot/etc",
 		fmt.Sprintf("%s-work", root.Label),
 	)
-	etcLocalePath := filepath.Join("/var/lib/abroot/etc", root.Label, "locales")
 	ic := &IntegrityCheck{
 		rootPath:   root.Partition.MountPoint,
 		systemPath: systemPath,
@@ -72,7 +71,6 @@ func NewIntegrityCheck(root ABRootPartition, repair bool) (*IntegrityCheck, erro
 		etcPaths: []string{
 			etcPath,
 			etcWorkPath,
-			etcLocalePath,
 		},
 	}
 

--- a/core/system.go
+++ b/core/system.go
@@ -241,7 +241,6 @@ func (s *ABSystem) GenerateSystemdUnits(rootPath string, root ABRootPartition) e
 	mounts := []varmount{
 		{"/var/home", "/home", "none", "bind"},
 		{"/var/opt", "/opt", "none", "bind"},
-		{"/var/lib/abroot/etc/" + root.Label + "/locales", "/.system/usr/lib/locale", "none", "bind"},
 		{"overlay", "/.system/etc", "overlay", "lowerdir=/.system/etc,upperdir=/var/lib/abroot/etc/" + root.Label + ",workdir=/var/lib/abroot/etc/" + root.Label + "-work"},
 	}
 


### PR DESCRIPTION
The bind mount prevents the system to provide all locales.

Since desktop image now provides all locales by default this mount point doesn't make sense anymore.

#286 