### PR TITLE
fix: handle invalid command for 'abroot pkg'

### DIFF
--- a/cmd/pkg.go
+++ b/cmd/pkg.go
@@ -181,6 +181,9 @@ func pkg(cmd *cobra.Command, args []string) error {
 			cmdr.Error.Printf(abroot.Trans("pkg.applyFailed"), err)
 			return err
 		}
+	default:
+		cmdr.Error.Println(abroot.Trans("pkg.unknownCommand", args[0]))
+		return nil
 	}
 
 	return nil

--- a/config/abroot.json
+++ b/config/abroot.json
@@ -13,6 +13,7 @@
     "iPkgMngAdd": "apt-get install -y",
     "iPkgMngRm": "apt-get remove -y --autoremove",
     "iPkgMngApi": "https://packages.vanillaos.org/api/pkg/{packageName}",
+    "iPkgMngStatus": 1,
 
     "differURL": "https://differ.vanillaos.org",
 

--- a/core/packages.go
+++ b/core/packages.go
@@ -81,7 +81,7 @@ func NewPackageManager(dryRun bool) (*PackageManager, error) {
 		baseDir = DryRunPackagesBaseDir
 	}
 
-	err := os.MkdirAll(baseDir, 0755)
+	err := os.MkdirAll(baseDir, 0o755)
 	if err != nil {
 		PrintVerboseErr("PackageManager.NewPackageManager", 0, err)
 		return nil, err
@@ -92,7 +92,7 @@ func NewPackageManager(dryRun bool) (*PackageManager, error) {
 		err = os.WriteFile(
 			filepath.Join(baseDir, PackagesAddFile),
 			[]byte(""),
-			0644,
+			0o644,
 		)
 		if err != nil {
 			PrintVerboseErr("PackageManager.NewPackageManager", 1, err)
@@ -105,7 +105,7 @@ func NewPackageManager(dryRun bool) (*PackageManager, error) {
 		err = os.WriteFile(
 			filepath.Join(baseDir, PackagesRemoveFile),
 			[]byte(""),
-			0644,
+			0o644,
 		)
 		if err != nil {
 			PrintVerboseErr("PackageManager.NewPackageManager", 2, err)
@@ -118,7 +118,7 @@ func NewPackageManager(dryRun bool) (*PackageManager, error) {
 		err = os.WriteFile(
 			filepath.Join(baseDir, PackagesUnstagedFile),
 			[]byte(""),
-			0644,
+			0o644,
 		)
 		if err != nil {
 			PrintVerboseErr("PackageManager.NewPackageManager", 3, err)
@@ -220,7 +220,8 @@ func (p *PackageManager) Add(pkg string) error {
 	return p.writeAddPackages(pkgsAdd)
 }
 
-// Remove removes a package from the packages.add file
+// Remove either removes a manually added package from packages.add or adds
+// a package to be deleted into packages.remove
 func (p *PackageManager) Remove(pkg string) error {
 	PrintVerboseInfo("PackageManager.Remove", "running...")
 
@@ -455,7 +456,7 @@ func (p *PackageManager) writePackages(file string, pkgs []string) error {
 			continue
 		}
 
-		_, err = f.WriteString(fmt.Sprintf("%s\n", pkg))
+		_, err = fmt.Fprintf(f, "%s\n", pkg)
 		if err != nil {
 			PrintVerboseErr("PackageManager.writePackages", 1, err)
 			return err
@@ -664,7 +665,7 @@ func (p *PackageManager) AcceptUserAgreement() error {
 	err := os.WriteFile(
 		PkgManagerUserAgreementFile,
 		[]byte(time.Now().String()),
-		0644,
+		0o644,
 	)
 	if err != nil {
 		PrintVerboseErr("PackageManager.AcceptUserAgreement", 0, err)

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -40,6 +40,7 @@ pkg:
   use: "pkg"
   long: "Install and manage packages."
   short: "Manage packages"
+  unknownCommand: "Unknown command '%s'. Run 'abroot pkg --help' for usage examples."
   rootRequired: "You must be root to run this command."
   failedGettingPkgManagerInstance: "Failed to get package manager instance: %s\n"
   noPackageNameProvided: "You must provide at least one package name for this operation."


### PR DESCRIPTION
Show an error when the user passes an invalid argument for 'abroot pkg' instead of exiting silently. This commit also adds "iPkgMngStatus" to the sample abroot.json so that the pkg command appears when testing locally.

Pinging @kbdharun since I added a new translation string. Not sure if some extra action is required.