### PR TITLE
fix [#302]: creates symlinks back to root

### DIFF
--- a/core/system.go
+++ b/core/system.go
@@ -295,6 +295,31 @@ Options=%s
 	return nil
 }
 
+func (s *ABSystem) CreateRootSymlinks(systemNewPath string) error {
+	PrintVerboseInfo("ABSystem.CreateRootSymlinks", "creating symlinks")
+	links := []string{"mnt", "proc", "run", "dev", "media", "root", "sys", "tmp", "var"}
+
+	for _, link := range links {
+		linkName := filepath.Join(systemNewPath, link)
+
+		err := os.RemoveAll(linkName)
+		if err != nil {
+			PrintVerboseErr("ABSystem.CreateRootSymlinks", 1, err)
+			return err
+		}
+
+		targetName := filepath.Join("/", link)
+
+		err = os.Symlink(targetName, linkName)
+		if err != nil {
+			PrintVerboseErr("ABSystem.CreateRootSymlinks", 2, err)
+			return err
+		}
+	}
+
+	return nil
+}
+
 // RunOperation executes a root-switching operation from the options below:
 //
 //	UPGRADE:
@@ -727,6 +752,13 @@ func (s *ABSystem) RunOperation(operation ABSystemOperation) error {
 	)
 	if err != nil {
 		PrintVerboseErr("ABSystem.RunOperation", 7.7, err)
+		return err
+	}
+
+	// Create links back to the root system
+	err = s.CreateRootSymlinks(systemNew)
+	if err != nil {
+		PrintVerboseErr("ABSystem.RunOperation", 7.8, err)
 		return err
 	}
 


### PR DESCRIPTION
Symlinks that point to specific folders on the root like /etc/mtab, which points to ../proc/self/mounts are broken because they would point to /.system/proc/... which does not contain the relevant information.

This PR points them back to /proc, /run and so on to prevent these issues. 

Tested in a VM.

Fixes #302