### PR TITLE
feat: Bump Orchid to v0.6.0, usage localization

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -29,6 +29,7 @@ func New(version string, fs embed.FS) *cmdr.App {
 	abroot = cmdr.NewApp("abroot", version, fs)
 	return abroot
 }
+
 func NewRootCommand(version string) *cmdr.Command {
 	root := cmdr.NewCommand(
 		abroot.Trans("abroot.use"),
@@ -38,7 +39,7 @@ func NewRootCommand(version string) *cmdr.Command {
 		WithPersistentBoolFlag(
 			cmdr.NewBoolFlag(
 				verboseFlag,
-				"v",
+				"V",
 				abroot.Trans("abroot.verboseFlag"),
 				false))
 	root.Version = version

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/vanilla-os/abroot
 
-go 1.21.4
+go 1.22
 
 require (
 	github.com/containers/buildah v1.35.1
@@ -15,7 +15,7 @@ require (
 	github.com/spf13/cobra v1.8.0
 	github.com/spf13/viper v1.18.2
 	github.com/vanilla-os/differ/diff v0.0.0-20240202135932-673de99cc540
-	github.com/vanilla-os/orchid v0.5.0
+	github.com/vanilla-os/orchid v0.6.0
 	github.com/vanilla-os/prometheus v1.0.0
 	github.com/vanilla-os/sdk v0.0.0-20240424182549-7fbf2ce02046
 	golang.org/x/sys v0.18.0

--- a/go.sum
+++ b/go.sum
@@ -459,6 +459,8 @@ github.com/vanilla-os/differ/diff v0.0.0-20240202135932-673de99cc540 h1:KrNjRudM
 github.com/vanilla-os/differ/diff v0.0.0-20240202135932-673de99cc540/go.mod h1:HMg24arXCutcwngVaJ4DQuhwLmS8CA/CuVSjEyIxFpw=
 github.com/vanilla-os/orchid v0.5.0 h1:QAOjJ2VcyND5TxK0XYUEu+dysxXicRHhV6i/07S47mk=
 github.com/vanilla-os/orchid v0.5.0/go.mod h1:dNPvHxofO4hEXodEKXp0nLQDZhoHh8evCUXc6X1xLao=
+github.com/vanilla-os/orchid v0.6.0 h1:aH7i621QrqtbspGUie4To28zCk1u1UvGHGzL11wdldE=
+github.com/vanilla-os/orchid v0.6.0/go.mod h1:dNPvHxofO4hEXodEKXp0nLQDZhoHh8evCUXc6X1xLao=
 github.com/vanilla-os/prometheus v1.0.0 h1:je+vWK9Ir1SzCIz2yoSE3tFmGKli4Q1z/LQ5mNk/+Pc=
 github.com/vanilla-os/prometheus v1.0.0/go.mod h1:CPWeG0LJW4gHcLHSkqx9jANi5574a03R3ihWNy4PIig=
 github.com/vanilla-os/sdk v0.0.0-20240424182549-7fbf2ce02046 h1:FYVQ7Suwq2O7D7Nm1XiWcy78M5z2PHd/HZJYFBiJ9HM=

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -5,6 +5,18 @@ abroot:
   short: "ABRoot provides full immutability and atomicity by performing transactions
     between 2 root partitions (A<->B)"
   verboseFlag: "show more detailed output"
+  msg:
+    help: "Show help for abroot."
+    version: "Show version for abroot."
+    usage: "Usage"
+    aliases: "Aliases"
+    examples: "Examples"
+    availableCommands: "Available Commands"
+    additionalCommands: "Additional Commands"
+    flags: "Flags"
+    globalFlags: "Global Flags"
+    additionalHelpTopics: "Additional help topics"
+    moreInfo: "Use %s for more information about a command"
 
 kargs:
   use: "kargs"

--- a/main.go
+++ b/main.go
@@ -22,9 +22,7 @@ import (
 	"github.com/vanilla-os/orchid/cmdr"
 )
 
-var (
-	Version = "2.0.1"
-)
+var Version = "2.0.1"
 
 //go:embed locales/*.yml
 var fs embed.FS
@@ -39,7 +37,20 @@ func main() {
 
 	// root command
 	root := cmd.NewRootCommand(Version)
-	abroot.CreateRootCommand(root)
+	abroot.CreateRootCommand(root, abroot.Trans("abroot.msg.help"), abroot.Trans("abroot.msg.version"))
+
+	msgs := cmdr.UsageStrings{
+		Usage:                abroot.Trans("abroot.msg.usage"),
+		Aliases:              abroot.Trans("abroot.msg.aliases"),
+		Examples:             abroot.Trans("abroot.msg.examples"),
+		AvailableCommands:    abroot.Trans("abroot.msg.availableCommands"),
+		AdditionalCommands:   abroot.Trans("abroot.msg.additionalCommands"),
+		Flags:                abroot.Trans("abroot.msg.flags"),
+		GlobalFlags:          abroot.Trans("abroot.msg.globalFlags"),
+		AdditionalHelpTopics: abroot.Trans("abroot.msg.additionalHelpTopics"),
+		MoreInfo:             abroot.Trans("abroot.msg.moreInfo"),
+	}
+	abroot.SetUsageStrings(msgs)
 
 	upgrade := cmd.NewUpgradeCommand()
 	root.AddCommand(upgrade)


### PR DESCRIPTION
Also changed verbose flag shorthand to uppercase "V" so it doesn't conflict with the version shorthand that is default from Cobra.