### PR TITLE
saves configuration to new root after upgrade

### DIFF
--- a/core/system.go
+++ b/core/system.go
@@ -408,7 +408,7 @@ func (s *ABSystem) RunOperation(operation ABSystemOperation) error {
 		return pkgM.ClearUnstagedPackages()
 	}, nil, 10, &goodies.NoErrorHandler{}, false)
 
-	// Stage 5: Write abimage.abr.new to future/
+	// Stage 5: Write abimage.abr.new and config to future/
 	// ------------------------------------------------
 	PrintVerboseSimple("[Stage 5] -------- ABSystemRunOperation")
 
@@ -427,6 +427,12 @@ func (s *ABSystem) RunOperation(operation ABSystemOperation) error {
 	err = abimage.WriteTo(partFuture.Partition.MountPoint, "new")
 	if err != nil {
 		PrintVerboseErr("ABSystem.RunOperation", 5.2, err)
+		return err
+	}
+
+	err = settings.WriteConfigToFile(filepath.Join(systemNew, "/usr/share/abroot/abroot.json"))
+	if err != nil {
+		PrintVerboseErr("ABSystem.RunOperation", 5.25, err)
 		return err
 	}
 

--- a/settings/config.go
+++ b/settings/config.go
@@ -130,3 +130,8 @@ func init() {
 
 	Cnf.FullImageName = fmt.Sprintf("%s/%s:%s", Cnf.Registry, Cnf.Name, Cnf.Tag)
 }
+
+// WriteConfigToFile writes the current configuration to a file
+func WriteConfigToFile(file string) error {
+	return viper.WriteConfigAs(file)
+}


### PR DESCRIPTION
This will save the configuration which was used to create the root to the system configuration. 
This ensures that there is always a valid configuration in the /usr directory. 

This is also required to implement #317 

Tested in a VM.