### PR TITLE
closes [#317]: Add encrypted var partition to config

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ The configuration file is a JSON file with the following structure:
     "partLabelB": "vos-b",
     "partLabelBoot": "vos-boot",
     "partLabelEfi": "vos-efi",
+    "PartCryptVar": "/dev/mapper/vos--var-var",
 
     "thinProvisioning": false,
     "thinInitVolume": "",
@@ -108,6 +109,7 @@ The following table describes each of the configuration options:
 | `partLabelB` | The label of the partition dedicated to the system's `B` root. |
 | `partLabelBoot` | The label of the partition dedicated to the master boot. |
 | `partLabelEfi` | The label of the partition dedicated to the EFI boot. |
+| `PartCryptVar` | The encrypted partition to unlock during boot. On a non-lvm setup this would be something like `/dev/nvme1n1p3`. |
 | `thinProvisioning` | If set to `true`, ABRoot will use and look for a thin provisioning setup. Check the section about [thin provisioning](#thin-provisioning) for more information. |
 | `thinInitVolume` | The init volume of the thin provisioning setup. |
 | `libPathStates` | NOT_IMPLEMENTED |

--- a/cmd/unlock-var.go
+++ b/cmd/unlock-var.go
@@ -26,12 +26,6 @@ import (
 	"github.com/vanilla-os/orchid/cmdr"
 )
 
-type VarConfigError struct{}
-
-func (e *VarConfigError) Error() string {
-	return "reading the var disk from config is not implemented yet"
-}
-
 type VarInvalidError struct {
 	passedDisk string
 }
@@ -63,6 +57,7 @@ func NewUnlockVarCommand() *cmdr.Command {
 		),
 	)
 
+	// this is just meant for compatability with old Installations
 	cmd.WithStringFlag(
 		cmdr.NewStringFlag(
 			"var-disk",
@@ -126,7 +121,13 @@ func unlockVar(cmd *cobra.Command, _ []string) error {
 	}
 
 	if varDisk == "" {
-		return &VarConfigError{}
+		if settings.Cnf.PartCryptVar == "" {
+			cmdr.Error.Println("Encrypted var partition not found in configuration.")
+			os.Exit(3)
+			return nil
+		}
+
+		varDisk = settings.Cnf.PartCryptVar
 	}
 
 	dryRun, err := cmd.Flags().GetBool("dry-run")

--- a/cmd/unlock-var.go
+++ b/cmd/unlock-var.go
@@ -76,6 +76,7 @@ func unlockVarCmd(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		cmdr.Error.Println(err)
 		os.Exit(1)
+		return nil
 	}
 	return nil
 }
@@ -83,6 +84,7 @@ func unlockVarCmd(cmd *cobra.Command, args []string) error {
 func unlockVar(cmd *cobra.Command, _ []string) error {
 	if !core.RootCheck(false) {
 		cmdr.Error.Println("You must be root to run this command.")
+		os.Exit(2)
 		return nil
 	}
 

--- a/config/abroot.json
+++ b/config/abroot.json
@@ -22,6 +22,7 @@
     "partLabelB": "vos-b",
     "partLabelBoot": "vos-boot",
     "partLabelEfi": "vos-efi",
+    "PartCryptVar": "/dev/mapper/vos--var-var",
 
     "thinProvisioning": false,
     "thinInitVolume": "",

--- a/core/disk-manager.go
+++ b/core/disk-manager.go
@@ -220,5 +220,5 @@ func (p *Partition) IsDevMapper() bool {
 
 // IsEncrypted returns whether the partition is encrypted
 func (p *Partition) IsEncrypted() bool {
-	return strings.HasPrefix(p.Device, "luks-")
+	return strings.HasPrefix(p.FsType, "crypto_")
 }

--- a/core/system.go
+++ b/core/system.go
@@ -430,6 +430,18 @@ func (s *ABSystem) RunOperation(operation ABSystemOperation) error {
 		return err
 	}
 
+	varParent := s.RootM.VarPartition.Parent
+	if varParent != nil && varParent.IsEncrypted() {
+		device := varParent.Device
+		if varParent.IsDevMapper() {
+			device = "/dev/mapper/" + device
+		} else {
+			device = "/dev/" + device
+		}
+
+		settings.Cnf.PartCryptVar = device
+	}
+
 	err = settings.WriteConfigToFile(filepath.Join(systemNew, "/usr/share/abroot/abroot.json"))
 	if err != nil {
 		PrintVerboseErr("ABSystem.RunOperation", 5.25, err)

--- a/settings/config.go
+++ b/settings/config.go
@@ -14,6 +14,7 @@ package settings
 */
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 
@@ -133,5 +134,17 @@ func init() {
 
 // WriteConfigToFile writes the current configuration to a file
 func WriteConfigToFile(file string) error {
-	return viper.WriteConfigAs(file)
+	jsonOutput, err := json.MarshalIndent(Cnf, "", "    ")
+	if err != nil {
+		return err
+	}
+
+	outputFile, err := os.OpenFile(file, os.O_WRONLY|os.O_TRUNC, 0o644)
+	if err != nil {
+		return err
+	}
+
+	_, err = outputFile.Write(jsonOutput)
+
+	return err
 }

--- a/settings/config.go
+++ b/settings/config.go
@@ -50,6 +50,7 @@ type Config struct {
 	PartLabelB    string `json:"partLabelB"`
 	PartLabelBoot string `json:"partLabelBoot"`
 	PartLabelEfi  string `json:"partLabelEfivar"`
+	PartCryptVar  string `json:"PartCryptVar"`
 
 	// Structure
 	ThinProvisioning bool   `json:"thinProvisioning"`
@@ -117,6 +118,7 @@ func init() {
 		PartLabelB:    viper.GetString("partLabelB"),
 		PartLabelBoot: viper.GetString("partLabelBoot"),
 		PartLabelEfi:  viper.GetString("partLabelEfi"),
+		PartCryptVar:  viper.GetString("PartCryptVar"),
 
 		// Structure
 		ThinProvisioning: viper.GetBool("thinProvisioning"),


### PR DESCRIPTION
This allows unlocking the var partition during boot without specifying which one it is. 

Closes #317 

I would like to merge this while we're in beta to guarantee that all stable versions have the correct config.

Also, I can split this PR into multiple if necessary. I wouldn't want to squash these commits. 