### PR TITLE
fixes [#328]: detect image being larger than root

### DIFF
--- a/core/utils.go
+++ b/core/utils.go
@@ -14,10 +14,14 @@ package core
 */
 
 import (
+	"bytes"
+	"errors"
 	"fmt"
 	"io"
 	"os"
 	"os/exec"
+	"strconv"
+	"strings"
 )
 
 var abrootDir = "/etc/abroot"
@@ -121,4 +125,29 @@ func isDeviceLUKSEncrypted(devicePath string) (bool, error) {
 	}
 
 	return true, nil
+}
+
+// getDirSize calculates the total size of a directory recursively.
+//
+// FIXME: find a way to avoid using du and any other external command
+func getDirSize(path string) (int64, error) {
+	cmd := exec.Command("du", "-s", "-b", path)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	err := cmd.Run()
+	if err != nil {
+		return 0, err
+	}
+
+	output := strings.Fields(out.String())
+	if len(output) == 0 {
+		return 0, errors.New("failed to get directory size")
+	}
+
+	size, err := strconv.ParseInt(output[0], 10, 64)
+	if err != nil {
+		return 0, err
+	}
+
+	return size, nil
 }


### PR DESCRIPTION
This is largely based on #313 and fixes #328

Different from #313 this only checks if the image could even fit in the root, ignoring available space.

It detects early when the image is larger than the root (or half the root on thin provisioning) and exits. 