### PR TITLE
writes a package summary file

### DIFF
--- a/core/system.go
+++ b/core/system.go
@@ -448,6 +448,12 @@ func (s *ABSystem) RunOperation(operation ABSystemOperation) error {
 		return err
 	}
 
+	err = pkgM.WriteSummaryToFile(filepath.Join(systemNew, "/usr/share/abroot/package-summary"))
+	if err != nil {
+		PrintVerboseErr("ABSystem.RunOperation", 5.26, err)
+		return err
+	}
+
 	// from this point on, it is not possible to stop the upgrade
 	// so we remove the stage file. Note that interrupting the upgrade
 	// from this point on will not leave the system in an inconsistent


### PR DESCRIPTION
It writes the added and removed packages in a file in the new root.
This allows programs to check what additional packages the image contains. 

It can possibly be used in the future for abroot status. 

It's also needed for https://github.com/Vanilla-OS/desktop-image/issues/192


Tested in a VM with both no packages and one added plus one removed package.