### PR TITLE
Mount a custom home partition

### DIFF
--- a/cmd/mount-sys.go
+++ b/cmd/mount-sys.go
@@ -124,12 +124,6 @@ func mountSys(cmd *cobra.Command, _ []string) error {
 		os.Exit(8)
 	}
 
-	err = makeSymlinks(dryRun)
-	if err != nil {
-		cmdr.Error.Println(err)
-		os.Exit(9)
-	}
-
 	if dryRun {
 		cmdr.Info.Println("Dry run complete.")
 	} else {
@@ -206,30 +200,6 @@ func mountOverlayMounts(rootLabel string, dryRun bool) error {
 	}
 
 	return nil
-}
-
-func makeSymlinks(dryRun bool) error {
-	type symlink struct {
-		from string
-		to string
-	}
-
-	symlinks := []symlink{
-		{"/var/home", "/home"},
-	}
-
-	for _, symlink := range symlinks {
-		cmdr.FgDefault.Println("symliking " + symlink.from + " to " + symlink.to)
-		if !dryRun {
-			err := syscall.Symlink(symlink.from, symlink.to)
-			if err != nil {
-				return err
-			}
-		}
-	}
-
-	return nil
-
 }
 
 func adjustFstab(uuid string, dryRun bool) error {


### PR DESCRIPTION
This is kinda part one in the process to support custom home partitions. This a sort of roadmap of the process:

- [x] Implement mounting custom home partitions
- [ ] Implement decrypting encrypted home partitions 
Up till this point, to add a custom home partition you have to mess around with `abroot.json` and filesystem labels yourself.
- [x] Implement adding a custom home partition in the [Vanilla Installer](https://github.com/Vanilla-OS/vanilla-installer)
- [ ] Implement encrypting the home partition in the installer
- [ ] Implement adding an encrypted home partition in the installer. This could also extend to adding an encrypted var partition as well