### PR TITLE
close [#376 #379]: Symlink data folders to /var

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,6 @@ The configuration file is a JSON file with the following structure:
 
 ```json
 {
-    "autoRepair": true,
     "maxParallelDownloads": 2,
 
     "registry": "ghcr.io",
@@ -88,7 +87,6 @@ The following table describes each of the configuration options:
 
 | Option | Description |
 | --- | --- |
-| `autoRepair` | If set to `true`, ABRoot will automatically try to repair the system if a broken structure is detected during a transaction. |
 | `maxParallelDownloads` | The maximum number of parallel downloads to perform when updating the system. |
 | `registry` | The registry to use when pulling OCI images. |
 | `registryService` | The registry service to use when pulling OCI images. |

--- a/README.md
+++ b/README.md
@@ -80,9 +80,7 @@ The configuration file is a JSON file with the following structure:
     "PartCryptVar": "/dev/mapper/vos--var-var",
 
     "thinProvisioning": false,
-    "thinInitVolume": "",
-
-    "libPathStates": "/var/lib/abroot/states"
+    "thinInitVolume": ""
 }
 ```
 
@@ -114,7 +112,6 @@ The following table describes each of the configuration options:
 | `PartCryptVar` | The encrypted partition to unlock during boot. On a non-lvm setup, this would be something like `/dev/nvme1n1p3`. |
 | `thinProvisioning` | If set to `true`, ABRoot will use and look for a thin provisioning setup. Check the section about [thin provisioning](#thin-provisioning) for more information. |
 | `thinInitVolume` | The init volume of the thin provisioning setup. |
-| `libPathStates` | NOT_IMPLEMENTED |
 
 ## How it works
 

--- a/config/abroot.json
+++ b/config/abroot.json
@@ -1,5 +1,4 @@
 {
-    "autoRepair": true,
     "maxParallelDownloads": 2,
 
     "registry": "ghcr.io",

--- a/config/abroot.json
+++ b/config/abroot.json
@@ -28,7 +28,5 @@
     "PartCryptVar": "/dev/mapper/vos--var-var",
 
     "thinProvisioning": false,
-    "thinInitVolume": "",
-
-    "libPathStates": "/var/lib/abroot/states"
+    "thinInitVolume": ""
 }

--- a/core/integrity.go
+++ b/core/integrity.go
@@ -17,8 +17,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-
-	"github.com/vanilla-os/abroot/settings"
 )
 
 type IntegrityCheck struct {
@@ -66,7 +64,6 @@ func NewIntegrityCheck(root ABRootPartition, repair bool) (*IntegrityCheck, erro
 			"/sys",
 			"/tmp",
 			"/var",
-			settings.Cnf.LibPathStates,
 		},
 		etcPaths: []string{
 			etcPath,

--- a/core/integrity.go
+++ b/core/integrity.go
@@ -29,6 +29,11 @@ var linksToRepair = [...][2]string{
 	{".system/libx32", "libx32"},
 	{".system/sbin", "sbin"},
 	{".system/usr", "usr"},
+	{"var/home", "home"},
+	{"var/media", "media"},
+	{"var/mnt", "mnt"},
+	{"var/opt", "opt"},
+	{"var/root", "root"},
 }
 
 // paths that must exist in the root partition
@@ -36,18 +41,18 @@ var pathsToRepair = [...]string{
 	".system",
 	"boot",
 	"dev",
-	"home",
-	"media",
-	"mnt",
-	"opt",
 	"part-future",
 	"proc",
-	"root",
 	"run",
 	"srv",
 	"sys",
 	"tmp",
 	"var",
+	"var/home",
+	"var/media",
+	"var/mnt",
+	"var/opt",
+	"var/root",
 }
 
 func RepairRootIntegrity(rootPath string) (err error) {

--- a/core/integrity.go
+++ b/core/integrity.go
@@ -14,7 +14,6 @@ package core
 */
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
 )
@@ -24,18 +23,12 @@ type IntegrityCheck struct {
 	systemPath    string
 	standardLinks []string
 	rootPaths     []string
-	etcPaths      []string
 }
 
 // NewIntegrityCheck creates a new IntegrityCheck instance for the given root
 // partition, and returns a pointer to it or an error if something went wrong
 func NewIntegrityCheck(root ABRootPartition, repair bool) (*IntegrityCheck, error) {
 	systemPath := filepath.Join(root.Partition.MountPoint, "/.system")
-	etcPath := filepath.Join("/var/lib/abroot/etc", root.Label)
-	etcWorkPath := filepath.Join(
-		"/var/lib/abroot/etc",
-		fmt.Sprintf("%s-work", root.Label),
-	)
 	ic := &IntegrityCheck{
 		rootPath:   root.Partition.MountPoint,
 		systemPath: systemPath,
@@ -64,10 +57,6 @@ func NewIntegrityCheck(root ABRootPartition, repair bool) (*IntegrityCheck, erro
 			"/sys",
 			"/tmp",
 			"/var",
-		},
-		etcPaths: []string{
-			etcPath,
-			etcWorkPath,
 		},
 	}
 
@@ -104,13 +93,6 @@ func (ic *IntegrityCheck) check(repair bool) error {
 		finalPath := filepath.Join(ic.rootPath, path)
 		if !fileExists(finalPath) {
 			repairPaths = append(repairPaths, finalPath)
-		}
-	}
-
-	// check if etc paths exist
-	for _, path := range ic.etcPaths {
-		if !fileExists(path) {
-			repairPaths = append(repairPaths, path)
 		}
 	}
 

--- a/core/system.go
+++ b/core/system.go
@@ -614,6 +614,11 @@ func (s *ABSystem) RunOperation(operation ABSystemOperation) error {
 	oldUpperEtc := fmt.Sprintf("/var/lib/abroot/etc/%s", presentEtc.Label)
 	newUpperEtc := fmt.Sprintf("/var/lib/abroot/etc/%s", futureEtc.Label)
 
+	// make sure the future etc directories exist, ignoring errors
+	newWorkEtc := fmt.Sprintf("/var/lib/abroot/etc/%s-work", futureEtc.Label)
+	os.MkdirAll(newUpperEtc, 0o755)
+	os.MkdirAll(newWorkEtc, 0o755)
+
 	err = EtcBuilder.ExtBuildCommand(oldEtc, systemNew+"/sysconf", oldUpperEtc, newUpperEtc)
 	if err != nil {
 		PrintVerboseErr("AbSystem.RunOperation", 8.2, err)

--- a/core/system.go
+++ b/core/system.go
@@ -280,7 +280,7 @@ func (s *ABSystem) RunOperation(operation ABSystemOperation) error {
 		return partFuture.Partition.Unmount()
 	}, nil, 90, &goodies.NoErrorHandler{}, false)
 
-	_, err = NewIntegrityCheck(partFuture, settings.Cnf.AutoRepair)
+	err = RepairRootIntegrity(partFuture.Partition.MountPoint)
 	if err != nil {
 		PrintVerboseErr("ABSystem.RunOperation", 2.4, err)
 		return err

--- a/core/utils.go
+++ b/core/utils.go
@@ -63,7 +63,7 @@ func fileExists(path string) bool {
 
 // isLink checks if a path is a link
 func isLink(path string) bool {
-	if _, err := os.Lstat(path); err == nil {
+	if fileInfo, err := os.Lstat(path); err == nil && fileInfo.Mode().Type() == os.ModeSymlink {
 		PrintVerboseInfo("isLink", "Path is a link:", path)
 		return true
 	}

--- a/settings/config.go
+++ b/settings/config.go
@@ -60,9 +60,6 @@ type Config struct {
 	ThinProvisioning bool   `json:"thinProvisioning"`
 	ThinInitVolume   string `json:"thinInitVolume"`
 
-	// Lib
-	LibPathStates string `json:"libPathStates"`
-
 	// Virtual
 	FullImageName string
 }
@@ -135,9 +132,6 @@ func init() {
 		// Structure
 		ThinProvisioning: viper.GetBool("thinProvisioning"),
 		ThinInitVolume:   viper.GetString("thinInitVolume"),
-
-		// Lib
-		LibPathStates: viper.GetString("libPathStates"),
 
 		// Virtual
 		FullImageName: "",

--- a/settings/config.go
+++ b/settings/config.go
@@ -23,7 +23,6 @@ import (
 
 type Config struct {
 	// Common
-	AutoRepair           bool `json:"autoRepair"`
 	MaxParallelDownloads uint `json:"maxParallelDownloads"`
 
 	// Registry
@@ -96,7 +95,6 @@ func init() {
 
 	Cnf = &Config{
 		// Common
-		AutoRepair:           viper.GetBool("autoRepair"),
 		MaxParallelDownloads: viper.GetUint("maxParallelDownloads"),
 
 		// Registry


### PR DESCRIPTION
This PR moves all folders that have persistent data from the root to /var. This will ensure that all user edited files are kept across upgrades.

This also makes use of symlinks instead of bind mounts since this is more flexible. It allows mounting something to /home for example, since that will automatically mount to /var/home due to the symlink, which was not possible before.

I recommend reviewing the commits instead of all changes, since all changes combined might be a bit confusing.

Closes #376 
Fixes #379
