### PR TITLE
fix [#268]: makes the grub and initramfs commands configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,9 @@ The configuration file is a JSON file with the following structure:
     "iPkgMngApi": "https://packages.vanillaos.org/api/pkg/{packageName}",
     "iPkgMngStatus": 0,
 
+    "updateInitramfsCmd": "lpkg --unlock && /usr/sbin/update-initramfs -u && lpkg --lock",
+    "updateGrubCmd": "/usr/sbin/grub-mkconfig -o '%s'",
+
     "differURL": "https://differ.vanillaos.org",
 
     "partLabelVar": "vos-var",
@@ -100,6 +103,8 @@ The following table describes each of the configuration options:
 | `iPkgMngRm` | The command to run when removing a package. It can be a command or a script. |
 | `iPkgMngApi` | The API endpoint to use when querying for package information. If not set, ABRoot will not check if a package exists before installing it. This could lead to errors. Take a look at our [Eratosthenes API](https://github.com/Vanilla-OS/Eratosthenes/blob/388e6f724dcda94ee60964e7b12a78ad79fb8a40/eratosthenes.py#L52) for an example. |
 | `iPkgMngStatus` | The status of the package manager feature. The value '0' means that the feature is disabled, the value '1' means enabled and the value '2' means that it will require user agreement the first time it is used. If the feature is disabled, it will not appear in the commands list. |
+| `updateInitramfsCmd` | Command that should be run to update the initramfs in /boot. |
+| `updateGrubCmd` | Command that should be run to update the grub config. %s needs to be included as a placeholder for the generated config file. |
 | `differURL` | The URL of the [Differ API](https://github.com/Vanilla-OS/Differ) service to use when comparing two OCI images. |
 | `partLabelVar` | The label of the partition dedicated to the system's `/var` directory. |
 | `partLabelA` | The label of the partition dedicated to the system's `A` root. |

--- a/config/abroot.json
+++ b/config/abroot.json
@@ -15,6 +15,9 @@
     "iPkgMngApi": "https://packages.vanillaos.org/api/pkg/{packageName}",
     "iPkgMngStatus": 1,
 
+    "updateInitramfsCmd": "lpkg --unlock && /usr/sbin/update-initramfs -u && lpkg --lock",
+    "updateGrubCmd": "/usr/sbin/grub-mkconfig -o '%s'",
+
     "differURL": "https://differ.vanillaos.org",
 
     "partLabelVar": "vos-var",

--- a/core/chroot.go
+++ b/core/chroot.go
@@ -62,7 +62,7 @@ func NewChroot(root string, rootUuid string, rootDevice string, mountUserEtc boo
 
 	// workaround for grub-mkconfig, not able to find the device
 	// inside a chroot environment
-	err := chroot.Execute("mount", []string{"--bind", "/", "/"})
+	err := chroot.Execute("mount --bind / /")
 	if err != nil {
 		PrintVerboseErr("NewChroot", 1, err)
 		return nil, err
@@ -126,10 +126,9 @@ func (c *Chroot) Close() error {
 // Execute runs a command in the chroot environment, the command is
 // a string and the arguments are a list of strings. If an error occurs
 // it is returned.
-func (c *Chroot) Execute(cmd string, args []string) error {
+func (c *Chroot) Execute(cmd string) error {
 	PrintVerboseInfo("Chroot.Execute", "running...")
 
-	cmd = strings.Join(append([]string{cmd}, args...), " ")
 	PrintVerboseInfo("Chroot.Execute", "running command:", cmd)
 	e := exec.Command("chroot", c.root, "/bin/sh", "-c", cmd)
 	e.Stdout = os.Stdout
@@ -151,7 +150,7 @@ func (c *Chroot) ExecuteCmds(cmds []string) error {
 	PrintVerboseInfo("Chroot.ExecuteCmds", "running...")
 
 	for _, cmd := range cmds {
-		err := c.Execute(cmd, []string{})
+		err := c.Execute(cmd)
 		if err != nil {
 			PrintVerboseErr("Chroot.ExecuteCmds", 0, err)
 			return err

--- a/core/system.go
+++ b/core/system.go
@@ -504,28 +504,14 @@ func (s *ABSystem) RunOperation(operation ABSystemOperation) error {
 
 	generatedGrubConfigPath := "/boot/grub/grub.cfg"
 
-	err = chroot.ExecuteCmds(
-		[]string{
-			"grub-mkconfig -o " + generatedGrubConfigPath,
-		},
-	)
+	grubCommand := fmt.Sprintf(settings.Cnf.UpdateGrubCmd, generatedGrubConfigPath)
+	err = chroot.Execute(grubCommand)
 	if err != nil {
 		PrintVerboseErr("ABSystem.RunOperation", 7.1, err)
 		return err
 	}
 
-	preExec := settings.Cnf.IPkgMngPre
-	postExec := settings.Cnf.IPkgMngPost
-	initramfsArgs := []string{}
-	if preExec != "" {
-		initramfsArgs = append(initramfsArgs, preExec)
-	}
-	initramfsArgs = append(initramfsArgs, "update-initramfs -u")
-	if postExec != "" {
-		initramfsArgs = append(initramfsArgs, postExec)
-	}
-	initramfsArgs = append(initramfsArgs, "exit")
-	err = chroot.ExecuteCmds(initramfsArgs) // ensure initramfs is updated
+	err = chroot.Execute(settings.Cnf.UpdateInitramfsCmd) // ensure initramfs is updated
 	if err != nil {
 		PrintVerboseErr("ABSystem.RunOperation", 7.2, err)
 		return err

--- a/settings/config.go
+++ b/settings/config.go
@@ -41,6 +41,10 @@ type Config struct {
 	IPkgMngApi    string `json:"iPkgMngApi"`
 	IPkgMngStatus int    `json:"iPkgMngStatus"`
 
+	// Boot configuration commands
+	UpdateInitramfsCmd string `json:"updateInitramfsCmd"`
+	UpdateGrubCmd      string `json:"updateGrubCmd"`
+
 	// Package diff API (Differ)
 	DifferURL string `json:"differURL"`
 
@@ -82,6 +86,10 @@ func init() {
 	viper.SetConfigName("abroot")
 	viper.SetConfigType("json")
 
+	// VanillaOS specific defaults for backwards compatibility
+	viper.SetDefault("updateInitramfsCmd", "lpkg --unlock && /usr/sbin/update-initramfs -u && lpkg --lock")
+	viper.SetDefault("updateGrubCmd", "/usr/sbin/grub-mkconfig -o '%s'")
+
 	err := viper.ReadInConfig()
 	if err != nil {
 		return
@@ -108,6 +116,10 @@ func init() {
 		IPkgMngRm:     viper.GetString("iPkgMngRm"),
 		IPkgMngApi:    viper.GetString("iPkgMngApi"),
 		IPkgMngStatus: viper.GetInt("iPkgMngStatus"),
+
+		// Boot configuration commands
+		UpdateInitramfsCmd: viper.GetString("updateInitramfsCmd"),
+		UpdateGrubCmd:      viper.GetString("updateGrubCmd"),
 
 		// Package diff API (Differ)
 		DifferURL: viper.GetString("differURL"),

--- a/tests/chroot_test.go
+++ b/tests/chroot_test.go
@@ -64,7 +64,7 @@ func TestChroot(t *testing.T) {
 	}
 
 	// chroot test
-	err = chroot.Execute("touch", []string{"/test"})
+	err = chroot.Execute("touch /test")
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
This creates settings through which a distro can change the update-initramfs and the grub-mkconfig commands. ABRoot should not expect them to exist and to be in PATH.

Fixes #268 

Tested in a VM.