### PR TITLE
fixes flipped versions in update output

### DIFF
--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -233,7 +233,7 @@ func renderPackageDiff(added, upgraded, downgraded, removed []diff.PackageDiff) 
 		for _, pkg := range pkgSet.Set {
 			bulletItems = append(bulletItems, cmdr.BulletListItem{
 				Level: 1,
-				Text:  fmt.Sprintf(pkgFmt, pkg.Name+strings.Repeat(" ", largestPkgName-len(pkg.Name)), pkg.NewVersion, pkg.PreviousVersion),
+				Text:  fmt.Sprintf(pkgFmt, pkg.Name+strings.Repeat(" ", largestPkgName-len(pkg.Name)), pkg.PreviousVersion, pkg.NewVersion),
 			})
 		}
 		err := cmdr.BulletList.WithItems(bulletItems).Render()


### PR DESCRIPTION
When running "abroot upgrade --check-only", the output would look very wrong, since all the versions were flipped.