### PR TITLE
fixes integrity not able to remove directories

### DIFF
--- a/core/integrity.go
+++ b/core/integrity.go
@@ -96,7 +96,7 @@ func repairLink(sourceAbs, targetAbs string) (err error) {
 	}
 
 	if !isLink(target) {
-		err = os.Remove(target)
+		err = os.RemoveAll(target)
 		if err != nil && !os.IsNotExist(err) {
 			PrintVerboseErr("repairLink", 2, "Can't remove ", target, " : ", err)
 			return err


### PR DESCRIPTION
If integrity notices that a link is actually a directory it can't remove it if there is anything in it.  
This is a problem for example on Vanilla OS systems where these folders are not empty currently.