### PR TITLE
fixes issue with moving inexistant folder

### DIFF
--- a/core/integrity.go
+++ b/core/integrity.go
@@ -156,7 +156,7 @@ func fixupOlderSystems(rootPath string) (err error) {
 		legacyPath := filepath.Join(rootPath, path)
 		newPath := filepath.Join("/var", path)
 
-		if info, err := os.Lstat(legacyPath); err != nil || info.IsDir() {
+		if info, err := os.Lstat(legacyPath); err == nil && info.IsDir() {
 			err = exec.Command("mv", legacyPath, newPath).Run()
 			if err != nil {
 				PrintVerboseErr("fixupOlderSystems", 1, "could not move ", legacyPath, " to ", newPath, " : ", err)


### PR DESCRIPTION
If one of the legacy folders in the integrity check didn't exist it would try to move it anyway.

This only happens in very specific cases but it's better to fix it anyway. 