### PR TITLE
ignore errors during migration

### DIFF
--- a/core/integrity.go
+++ b/core/integrity.go
@@ -56,10 +56,7 @@ var pathsToRepair = [...]string{
 }
 
 func RepairRootIntegrity(rootPath string) (err error) {
-	err = fixupOlderSystems(rootPath)
-	if err != nil {
-		return err
-	}
+	fixupOlderSystems(rootPath)
 
 	err = repairLinks(rootPath)
 	if err != nil {
@@ -145,7 +142,7 @@ func repairPath(path string) (err error) {
 
 // this is here to keep compatibility with older systems
 // e.g. /media was a folder instead of a symlink to /var/media
-func fixupOlderSystems(rootPath string) (err error) {
+func fixupOlderSystems(rootPath string) {
 	paths := []string{
 		"media",
 		"mnt",
@@ -160,10 +157,9 @@ func fixupOlderSystems(rootPath string) (err error) {
 			err = exec.Command("mv", legacyPath, newPath).Run()
 			if err != nil {
 				PrintVerboseErr("fixupOlderSystems", 1, "could not move ", legacyPath, " to ", newPath, " : ", err)
-				return err
+				// if moving failed it probably means that it migrated successfully in the past
+				// so it's safe to ignore errors
 			}
 		}
 	}
-
-	return nil
 }


### PR DESCRIPTION
The migration isn't technically necessary, since the folders were unpredictable before anyway and recreating the mount points can be done manually. (If these folders contain any user mountpoints then that means that the users knows how to do that)

It's just a "nice to have" so the upgrade shouldn't fail just because this failed.


P.S. sorry for the many PRs. Testing all aspects of this is very difficult. I hope this is the last one of them.
