### PR TITLE
Add support for other distros

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ The following table describes each of the configuration options:
 | `iPkgMngStatus` | The status of the package manager feature. The value '0' means that the feature is disabled, the value '1' means enabled and the value '2' means that it will require user agreement the first time it is used. If the feature is disabled, it will not appear in the commands list. |
 | `updateInitramfsCmd` | Command that should be run to update the initramfs in /boot. |
 | `updateGrubCmd` | Command that should be run to update the grub config. %s needs to be included as a placeholder for the generated config file. |
+| `initramfsFormat` | The format string for the initramfs filename. This should include a `%s` placeholder for the kernel version. For example, `initrd.img-%s` or `initramfs-%s.img`. |
 | `differURL` | The URL of the [Differ API](https://github.com/Vanilla-OS/Differ) service to use when comparing two OCI images. |
 | `partLabelVar` | The label of the partition dedicated to the system's `/var` directory. |
 | `partLabelA` | The label of the partition dedicated to the system's `A` root. |

--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ The configuration file is a JSON file with the following structure:
 
     "updateInitramfsCmd": "lpkg --unlock && /usr/sbin/update-initramfs -u && lpkg --lock",
     "updateGrubCmd": "/usr/sbin/grub-mkconfig -o '%s'",
+    "initramfsFormat": "initrd.img-%s"
 
     "differURL": "https://differ.vanillaos.org",
 

--- a/core/grub.go
+++ b/core/grub.go
@@ -32,7 +32,7 @@ type Grub struct {
 }
 
 // generateABGrubConf generates a new grub config with the given details
-func generateABGrubConf(kernelVersion string, rootPath string, rootUuid string, rootLabel string, generatedGrubConfigPath string) error {
+func generateABGrubConf(kernelName string, rootPath string, rootUuid string, rootLabel string, generatedGrubConfigPath string) error {
 	PrintVerboseInfo("generateABGrubConf", "generating grub config for ABRoot")
 
 	kargs, err := KargsRead()
@@ -62,7 +62,7 @@ func generateABGrubConf(kernelVersion string, rootPath string, rootUuid string, 
 	confPath := filepath.Join(grubPath, "abroot.cfg")
 	template := `  search --no-floppy --fs-uuid --set=root %s
   linux   %s/vmlinuz-%s root=%s %s
-  initrd  %s/initrd.img-%s
+  initrd  %s/%s
 `
 
 	err = os.MkdirAll(grubPath, 0755)
@@ -71,7 +71,9 @@ func generateABGrubConf(kernelVersion string, rootPath string, rootUuid string, 
 		return err
 	}
 
-	abrootBootConfig := fmt.Sprintf(template, rootUuid, bootPrefix, kernelVersion, systemRoot, kargs, bootPrefix, kernelVersion)
+	initramfsName := fmt.Sprintf(settings.Cnf.InitramfsFormat, kernelName)
+
+	abrootBootConfig := fmt.Sprintf(template, rootUuid, bootPrefix, kernelName, systemRoot, kargs, bootPrefix, initramfsName)
 
 	generatedGrubConfigContents, err := os.ReadFile(filepath.Join(rootPath, generatedGrubConfigPath))
 	if err != nil {

--- a/core/kernel.go
+++ b/core/kernel.go
@@ -20,31 +20,35 @@ import (
 	"github.com/hashicorp/go-version"
 )
 
-// getKernelVersion returns the latest kernel version available in the root
-func getKernelVersion(bootPath string) string {
-	PrintVerboseInfo("getKernelVersion", "running...")
+// getKernelName returns the name of the latest kernel found in the boot directory
+func getKernelName(bootPath string) string {
+	PrintVerboseInfo("getKernelName", "running...")
 
 	kernelDir := filepath.Join(bootPath, "vmlinuz-*")
 	files, err := filepath.Glob(kernelDir)
 	if err != nil {
-		PrintVerboseErr("getKernelVersion", 0, err)
+		PrintVerboseErr("getKernelName", 0, err)
 		return ""
 	}
 
 	if len(files) == 0 {
-		PrintVerboseErr("getKernelVersion", 1, errors.New("no kernel found"))
+		PrintVerboseErr("getKernelName", 1, errors.New("no kernel found"))
 		return ""
 	}
 
 	var maxVer *version.Version
+	var latestKernel string
+
 	for _, file := range files {
 		verStr := filepath.Base(file)[8:]
 		ver, err := version.NewVersion(verStr)
-		if err != nil {
-			continue
-		}
-		if maxVer == nil || ver.GreaterThan(maxVer) {
-			maxVer = ver
+		if err == nil {
+			if maxVer == nil || ver.GreaterThan(maxVer) {
+				maxVer = ver
+				latestKernel = verStr
+			}
+		} else {
+			latestKernel = verStr
 		}
 	}
 
@@ -52,5 +56,5 @@ func getKernelVersion(bootPath string) string {
 		return maxVer.String()
 	}
 
-	return ""
+	return latestKernel
 }

--- a/core/system.go
+++ b/core/system.go
@@ -361,7 +361,7 @@ func (s *ABSystem) RunOperation(operation ABSystemOperation) error {
 		content,
 	)
 
-	// Stage 4: Extract the rootfs
+	// Stage 4: Extract the rootfs and use new abroot config
 	// ------------------------------------------------
 	PrintVerboseSimple("[Stage 4] -------- ABSystemRunOperation")
 
@@ -410,6 +410,13 @@ func (s *ABSystem) RunOperation(operation ABSystemOperation) error {
 	if err != nil {
 		PrintVerboseErr("ABSystem.RunOperation", 4.2, err)
 		return err
+	}
+
+	// Load system-wide abroot.json from the new root
+	newConfigFile := filepath.Join(systemNew, "usr", "share", "abroot", "abroot.json")
+	if _, err := os.Stat(newConfigFile); err == nil {
+		settings.AddConfigFile(newConfigFile)
+		PrintVerboseInfo("ABSystem.RunOperation", "Successfully loaded new abroot.json")
 	}
 
 	cq.Add(func(args ...interface{}) error {

--- a/core/system.go
+++ b/core/system.go
@@ -523,9 +523,9 @@ func (s *ABSystem) RunOperation(operation ABSystemOperation) error {
 		return err
 	}
 
-	newKernelVer := getKernelVersion(filepath.Join(systemNew, "boot"))
-	if newKernelVer == "" {
-		err := errors.New("could not get kernel version")
+	newKernelName := getKernelName(filepath.Join(systemNew, "boot"))
+	if newKernelName == "" {
+		err := errors.New("could not get kernel name")
 		PrintVerboseErr("ABSystem.RunOperation", 7.26, err)
 		return err
 	}
@@ -564,24 +564,24 @@ func (s *ABSystem) RunOperation(operation ABSystemOperation) error {
 		}
 
 		err = CopyFile(
-			filepath.Join(systemNew, "boot", "vmlinuz-"+newKernelVer),
-			filepath.Join(futureInitDir, "vmlinuz-"+newKernelVer),
+			filepath.Join(systemNew, "boot", fmt.Sprintf("vmlinuz-%s", newKernelName)),
+			filepath.Join(futureInitDir, fmt.Sprintf("vmlinuz-%s", newKernelName)),
 		)
 		if err != nil {
 			PrintVerboseErr("ABSystem.RunOperation", 7.5, err)
 			return err
 		}
 		err = CopyFile(
-			filepath.Join(systemNew, "boot", "initrd.img-"+newKernelVer),
-			filepath.Join(futureInitDir, "initrd.img-"+newKernelVer),
+			filepath.Join(systemNew, "boot", fmt.Sprintf(settings.Cnf.InitramfsFormat, newKernelName)),
+			filepath.Join(futureInitDir, fmt.Sprintf(settings.Cnf.InitramfsFormat, newKernelName)),
 		)
 		if err != nil {
 			PrintVerboseErr("ABSystem.RunOperation", 7.6, err)
 			return err
 		}
 
-		os.Remove(filepath.Join(systemNew, "boot", "vmlinuz-"+newKernelVer))
-		os.Remove(filepath.Join(systemNew, "boot", "initrd.img-"+newKernelVer))
+		os.Remove(filepath.Join(systemNew, "boot", fmt.Sprintf("vmlinuz-%s", newKernelName)))
+		os.Remove(filepath.Join(systemNew, "boot", fmt.Sprintf(settings.Cnf.InitramfsFormat, newKernelName)))
 
 		rootUuid = initPartition.Uuid
 	} else {
@@ -589,7 +589,7 @@ func (s *ABSystem) RunOperation(operation ABSystemOperation) error {
 	}
 
 	err = generateABGrubConf(
-		newKernelVer,
+		newKernelName,
 		systemNew,
 		rootUuid,
 		partFuture.Label,

--- a/settings/config.go
+++ b/settings/config.go
@@ -43,6 +43,7 @@ type Config struct {
 	// Boot configuration commands
 	UpdateInitramfsCmd string `json:"updateInitramfsCmd"`
 	UpdateGrubCmd      string `json:"updateGrubCmd"`
+	InitramfsFormat    string `json:"initramfsFormat"`
 
 	// Package diff API (Differ)
 	DifferURL string `json:"differURL"`
@@ -85,6 +86,7 @@ func init() {
 	// VanillaOS specific defaults for backwards compatibility
 	viper.SetDefault("updateInitramfsCmd", "lpkg --unlock && /usr/sbin/update-initramfs -u && lpkg --lock")
 	viper.SetDefault("updateGrubCmd", "/usr/sbin/grub-mkconfig -o '%s'")
+	viper.SetDefault("initramfsFormat", "initrd.img-%s")
 
 	err := viper.ReadInConfig()
 	if err != nil {
@@ -115,7 +117,7 @@ func init() {
 		// Boot configuration commands
 		UpdateInitramfsCmd: viper.GetString("updateInitramfsCmd"),
 		UpdateGrubCmd:      viper.GetString("updateGrubCmd"),
-
+		InitramfsFormat:    viper.GetString("initramfsFormat"),
 		// Package diff API (Differ)
 		DifferURL: viper.GetString("differURL"),
 

--- a/settings/config.go
+++ b/settings/config.go
@@ -95,6 +95,17 @@ func init() {
 
 	CnfFileUsed = viper.ConfigFileUsed()
 
+	updateConfig()
+}
+
+// AddConfigFile adds a new config file
+func AddConfigFile(file string) {
+	viper.SetConfigFile(file)
+	viper.MergeInConfig()
+	updateConfig()
+}
+
+func updateConfig() {
 	Cnf = &Config{
 		// Common
 		MaxParallelDownloads: viper.GetUint("maxParallelDownloads"),


### PR DESCRIPTION
[refactor getting kernel version](https://github.com/Vanilla-OS/ABRoot/commit/db6ed28e91538e6bc521bd8508bcc0d8d5eb47b2)
- Added initramfsFormat for using non initrd.img-%s initramfs file, e.g initramfs-%s.img
- [update grub.go for using initramfsFormat](https://github.com/Vanilla-OS/ABRoot/commit/ea697eede9aa2f43a75d51a65d0324ecf2d61444) is just continuing this commit

[use new system-wide abroot.json while upgrading](https://github.com/Vanilla-OS/ABRoot/commit/94e1867d21191217d7317297a1563dcf8318187c)
- Use part-future abroot.json while upgrading after unpack rootfs for correct load initramfsFormat while upgrading to image with non-default initramfsFormat

Tested on [Planifolia Desktop](https://github.com/nisel11/desktop-image) and [Vanilla-OS Desktop](https://github.com/vanilla-os/desktop-image) with Gnome Boxes VM (better retest)