### PR TITLE
adds flag to free up space if necessary

### DIFF
--- a/cmd/kargs.go
+++ b/cmd/kargs.go
@@ -63,7 +63,7 @@ func kargs(cmd *cobra.Command, args []string) error {
 			cmdr.Error.Println(err)
 			return err
 		}
-		err = aBsys.RunOperation(core.APPLY)
+		err = aBsys.RunOperation(core.APPLY, false)
 		if err != nil {
 			cmdr.Error.Println(abroot.Trans("pkg.applyFailed"))
 			return err

--- a/cmd/pkg.go
+++ b/cmd/pkg.go
@@ -49,6 +49,13 @@ func NewPkgCommand() *cmdr.Command {
 			abroot.Trans("pkg.forceEnableUserAgreementFlag"),
 			false))
 
+	cmd.WithBoolFlag(
+		cmdr.NewBoolFlag(
+			"delete-old-system",
+			"",
+			abroot.Trans("upgrade.deleteOld"),
+			false))
+
 	cmd.Args = cobra.MinimumNArgs(1)
 	cmd.ValidArgs = validPkgArgs
 	cmd.Example = "abroot pkg add <pkg>"
@@ -63,6 +70,12 @@ func pkg(cmd *cobra.Command, args []string) error {
 	}
 
 	dryRun, err := cmd.Flags().GetBool("dry-run")
+	if err != nil {
+		cmdr.Error.Println(err)
+		return err
+	}
+
+	freeSpace, err := cmd.Flags().GetBool("delete-old-system")
 	if err != nil {
 		cmdr.Error.Println(err)
 		return err
@@ -173,9 +186,9 @@ func pkg(cmd *cobra.Command, args []string) error {
 		}
 
 		if dryRun {
-			err = aBsys.RunOperation(core.DRY_RUN_APPLY)
+			err = aBsys.RunOperation(core.DRY_RUN_APPLY, freeSpace)
 		} else {
-			err = aBsys.RunOperation(core.APPLY)
+			err = aBsys.RunOperation(core.APPLY, freeSpace)
 		}
 		if err != nil {
 			cmdr.Error.Printf(abroot.Trans("pkg.applyFailed"), err)

--- a/cmd/update-initramfs.go
+++ b/cmd/update-initramfs.go
@@ -35,6 +35,13 @@ func NewUpdateInitfsCommand() *cmdr.Command {
 			abroot.Trans("updateInitramfs.dryRunFlag"),
 			false))
 
+	cmd.WithBoolFlag(
+		cmdr.NewBoolFlag(
+			"delete-old-system",
+			"",
+			abroot.Trans("upgrade.deleteOld"),
+			false))
+
 	cmd.Example = "abroot update-initramfs"
 
 	return cmd
@@ -52,6 +59,12 @@ func updateInitramfs(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	freeSpace, err := cmd.Flags().GetBool("delete-old-system")
+	if err != nil {
+		cmdr.Error.Println(err)
+		return err
+	}
+
 	aBsys, err := core.NewABSystem()
 	if err != nil {
 		cmdr.Error.Println(err)
@@ -59,9 +72,9 @@ func updateInitramfs(cmd *cobra.Command, args []string) error {
 	}
 
 	if dryRun {
-		err = aBsys.RunOperation(core.DRY_RUN_INITRAMFS)
+		err = aBsys.RunOperation(core.DRY_RUN_INITRAMFS, freeSpace)
 	} else {
-		err = aBsys.RunOperation(core.INITRAMFS)
+		err = aBsys.RunOperation(core.INITRAMFS, freeSpace)
 	}
 	if err != nil {
 		cmdr.Error.Printf(abroot.Trans("updateInitramfs.updateFailed"), err)

--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -55,6 +55,13 @@ func NewUpgradeCommand() *cmdr.Command {
 			abroot.Trans("upgrade.forceFlag"),
 			false))
 
+	cmd.WithBoolFlag(
+		cmdr.NewBoolFlag(
+			"delete-old-system",
+			"",
+			abroot.Trans("upgrade.deleteOld"),
+			false))
+
 	cmd.Example = "abroot upgrade"
 
 	return cmd
@@ -68,6 +75,12 @@ func upgrade(cmd *cobra.Command, args []string) error {
 	}
 
 	dryRun, err := cmd.Flags().GetBool("dry-run")
+	if err != nil {
+		cmdr.Error.Println(err)
+		return err
+	}
+
+	freeSpace, err := cmd.Flags().GetBool("delete-old-system")
 	if err != nil {
 		cmdr.Error.Println(err)
 		return err
@@ -185,7 +198,7 @@ func upgrade(cmd *cobra.Command, args []string) error {
 	}
 
 	cmdr.Info.Println(abroot.Trans("upgrade.checkingSystemUpdate"))
-	err = aBsys.RunOperation(operation)
+	err = aBsys.RunOperation(operation, freeSpace)
 	if err != nil {
 		if err == core.ErrNoUpdate {
 			cmdr.Info.Println(abroot.Trans("upgrade.noUpdateAvailable"))

--- a/core/system.go
+++ b/core/system.go
@@ -170,7 +170,7 @@ func (s *ABSystem) CreateRootSymlinks(systemNewPath string) error {
 //		Applies package changes, but doesn't update the system.
 //	INITRAMFS:
 //		Updates the initramfs for the future root, but doesn't update the system.
-func (s *ABSystem) RunOperation(operation ABSystemOperation) error {
+func (s *ABSystem) RunOperation(operation ABSystemOperation, freeSpace bool) error {
 	PrintVerboseInfo("ABSystem.RunOperation", "starting", operation)
 
 	cq := goodies.NewCleanupQueue()
@@ -374,8 +374,8 @@ func (s *ABSystem) RunOperation(operation ABSystemOperation) error {
 	abrootTrans := filepath.Join(partFuture.Partition.MountPoint, "abroot-trans")
 	systemOld := filepath.Join(partFuture.Partition.MountPoint, ".system")
 	systemNew := filepath.Join(partFuture.Partition.MountPoint, ".system.new")
-	if os.Getenv("ABROOT_FREE_SPACE") != "" {
-		PrintVerboseInfo("ABSystemRunOperation", "ABROOT_FREE_SPACE is set, deleting future system to free space, this is potentially harmful, assuming we are in a test environment")
+	if freeSpace || os.Getenv("ABROOT_FREE_SPACE") != "" {
+		PrintVerboseInfo("ABSystemRunOperation", "Deleting future system to free space, this will render the future root temporarily unavailable")
 		err := os.RemoveAll(systemOld)
 		if err != nil {
 			PrintVerboseErr("ABSystemRunOperation", 4, err)

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -106,6 +106,7 @@ upgrade:
   long: "Check for a new system image and apply it."
   short: "Upgrade the system"
   forceFlag: "force update even if the system is up to date"
+  deleteOld: "Delete old image to free up space, will make future root temporarily unusable."
   rootRequired: "You must be root to run this command."
   checkingSystemUpdate: "Checking for system updates..."
   checkingPackageUpdate: "Checking for package updates..."


### PR DESCRIPTION
If the changes to the system are bigger than the free space the operation will fail.
This flag enables the user to easily fix this situation.