### PR TITLE
feat[#272]: Improve removing package by checking if already installed

### DIFF
--- a/core/packages.go
+++ b/core/packages.go
@@ -242,6 +242,12 @@ func (p *PackageManager) Remove(pkg string) error {
 		return err
 	}
 
+	err = p.ExistsOnSystem(pkg)
+	if err != nil {
+		PrintVerboseErr("PackageManager.Remove", 1, err)
+		return err
+	}
+
 	// Add to unstaged packages first
 	upkgs, err := p.GetUnstagedPackages()
 	if err != nil {
@@ -683,6 +689,26 @@ func (p *PackageManager) ExistsInRepo(pkg string) error {
 	}
 
 	PrintVerboseInfo("PackageManager.ExistsInRepo", "package exists in repo")
+	return nil
+}
+
+func (p *PackageManager) ExistsOnSystem(pkg string) error {
+	PrintVerboseInfo("PackageManager.ExistsOnSystem", "running...")
+
+	PrintVerboseInfo("PackageManager.ExistsInRepo", "checking if package "+pkg+" exists on system: ")
+
+	packageListFile, err := os.ReadFile("/var/lib/dpkg/status")
+	if err != nil {
+		PrintVerboseErr("PackageManager.ExistsOnSystem", 0, err)
+		return err
+	}
+
+	if !strings.Contains(string(packageListFile), "Package: "+pkg) {
+		PrintVerboseInfo("PackageManager.ExistsInRepo", "package does not exist on system")
+		return fmt.Errorf("package does not exist on system: %s", pkg)
+	}
+
+	PrintVerboseInfo("PackageManager.ExistsInRepo", "package exists on system")
 	return nil
 }
 

--- a/core/packages.go
+++ b/core/packages.go
@@ -244,12 +244,6 @@ func (p *PackageManager) Remove(pkg string) error {
 		// FIXME: this should also check if the package is installed in
 		// different systems, not just debian-based ditros.. Since this is a
 		// distro specific feature, I'm leaving it as is for now.
-		err = p.ExistsInRepo(pkg)
-		if err != nil {
-			PrintVerboseErr("PackageManager.Remove", 1, err)
-			return err
-		}
-
 		err = p.ExistsOnSystem(pkg)
 		if err != nil {
 			PrintVerboseErr("PackageManager.Remove", 1, err)
@@ -709,7 +703,7 @@ func (p *PackageManager) ExistsOnSystem(pkg string) error {
 	packageListFile, err := os.ReadFile("/var/lib/dpkg/status")
 	if err != nil {
 		PrintVerboseErr("PackageManager.ExistsOnSystem", 0, err)
-		return nil
+		return p.ExistsInRepo(pkg)
 	}
 
 	if !strings.Contains(string(packageListFile), "Package: "+pkg) {

--- a/core/packages.go
+++ b/core/packages.go
@@ -232,20 +232,29 @@ func (p *PackageManager) Remove(pkg string) error {
 		return err
 	}
 
-	// Check if package exists in repo
-	// FIXME: this should also check if the package is actually installed
-	// in the system, not just if it exists in the repo. Since this is a distro
-	// specific feature, I'm leaving it as is for now.
-	err = p.ExistsInRepo(pkg)
+	// Check if package exists in packages.add
+	pkgsAddList, err := p.GetAddPackagesString(" ")
 	if err != nil {
 		PrintVerboseErr("PackageManager.Remove", 1, err)
 		return err
 	}
+	if !strings.Contains(pkgsAddList, pkg) {
 
-	err = p.ExistsOnSystem(pkg)
-	if err != nil {
-		PrintVerboseErr("PackageManager.Remove", 1, err)
-		return err
+		// Check if package exists in repo
+		// FIXME: this should also check if the package is installed in
+		// different systems, not just debian-based ditros.. Since this is a
+		// distro specific feature, I'm leaving it as is for now.
+		err = p.ExistsInRepo(pkg)
+		if err != nil {
+			PrintVerboseErr("PackageManager.Remove", 1, err)
+			return err
+		}
+
+		err = p.ExistsOnSystem(pkg)
+		if err != nil {
+			PrintVerboseErr("PackageManager.Remove", 1, err)
+			return err
+		}
 	}
 
 	// Add to unstaged packages first

--- a/core/packages.go
+++ b/core/packages.go
@@ -700,7 +700,7 @@ func (p *PackageManager) ExistsOnSystem(pkg string) error {
 	packageListFile, err := os.ReadFile("/var/lib/dpkg/status")
 	if err != nil {
 		PrintVerboseErr("PackageManager.ExistsOnSystem", 0, err)
-		return err
+		return nil
 	}
 
 	if !strings.Contains(string(packageListFile), "Package: "+pkg) {


### PR DESCRIPTION
An attempt at fixing #272 

This only works on debian-based systems so far, which means it works on Vanilla OS. However, if we need this to work on non-debian-based systems, we need to discuss how to create a method to configure how these packages are found in systems with different package managers. Perhaps we can add fields to `abroot.json` configure which file is read, and what pattern needs to be matched to find a package (similar to the iPkgMngApi field)