### PR TITLE
fixes writing full image name to config

### DIFF
--- a/core/system.go
+++ b/core/system.go
@@ -335,10 +335,10 @@ func (s *ABSystem) RunOperation(operation ABSystemOperation, freeSpace bool) err
 		// Handle case where an image for the current root may not exist
 		// in storage
 		if imageName == "" {
-			imageName = settings.Cnf.FullImageName
+			imageName = settings.GetFullImageNameWithTag()
 		}
 	default:
-		imageName = strings.Split(settings.Cnf.FullImageName, ":")[0]
+		imageName = settings.GetFullImageName()
 		imageName += "@" + imageDigest
 		labels["ABRoot.BaseImageDigest"] = imageDigest
 	}
@@ -426,7 +426,7 @@ func (s *ABSystem) RunOperation(operation ABSystemOperation, freeSpace bool) err
 		return err
 	}
 
-	abimage, err := NewABImage(imageDigest, settings.Cnf.FullImageName)
+	abimage, err := NewABImage(imageDigest, settings.GetFullImageNameWithTag())
 	if err != nil {
 		PrintVerboseErr("ABSystem.RunOperation", 5.1, err)
 		return err

--- a/settings/config.go
+++ b/settings/config.go
@@ -58,9 +58,6 @@ type Config struct {
 	// Structure
 	ThinProvisioning bool   `json:"thinProvisioning"`
 	ThinInitVolume   string `json:"thinInitVolume"`
-
-	// Virtual
-	FullImageName string
 }
 
 var Cnf *Config
@@ -130,12 +127,15 @@ func init() {
 		// Structure
 		ThinProvisioning: viper.GetBool("thinProvisioning"),
 		ThinInitVolume:   viper.GetString("thinInitVolume"),
-
-		// Virtual
-		FullImageName: "",
 	}
+}
 
-	Cnf.FullImageName = fmt.Sprintf("%s/%s:%s", Cnf.Registry, Cnf.Name, Cnf.Tag)
+func GetFullImageName() string {
+	return fmt.Sprintf("%s/%s", Cnf.Registry, Cnf.Name)
+}
+
+func GetFullImageNameWithTag() string {
+	return fmt.Sprintf("%s:%s", GetFullImageName(), Cnf.Tag)
 }
 
 // WriteConfigToFile writes the current configuration to a file


### PR DESCRIPTION
We shouldn't write the whole image name to the config file since it just duplicates it there.