### PR TITLE
fix [#408, #333]: config improvements

### DIFF
--- a/cmd/status.go
+++ b/cmd/status.go
@@ -122,7 +122,6 @@ func status(cmd *cobra.Command, args []string) error {
 		type status struct {
 			Present         string       `json:"present"`
 			Future          string       `json:"future"`
-			CnfFile         string       `json:"cnfFile"`
 			CPU             string       `json:"cpu"`
 			GPU             []string     `json:"gpu"`
 			Memory          string       `json:"memory"`
@@ -138,7 +137,6 @@ func status(cmd *cobra.Command, args []string) error {
 		s := status{
 			Present:         present.Label,
 			Future:          future.Label,
-			CnfFile:         settings.CnfFileUsed,
 			CPU:             specs.CPU,
 			GPU:             specs.GPU,
 			Memory:          specs.Memory,
@@ -244,11 +242,6 @@ func status(cmd *cobra.Command, args []string) error {
 		{Level: 1, Text: abroot.Trans("status.partitions.present", present.Label, presentMark)},
 		{Level: 1, Text: abroot.Trans("status.partitions.future", future.Label, futureMark)},
 	}).Render()
-
-	// Loaded Configuration: ...
-	cmdr.Bold.Print(abroot.Trans("status.loadedConfig") + " ")
-	cmdr.FgDefault.Println(settings.CnfFileUsed)
-	fmt.Println()
 
 	// Device Specification:
 	cmdr.Bold.Println(abroot.Trans("status.specs.title"))

--- a/core/conf.go
+++ b/core/conf.go
@@ -39,13 +39,13 @@ func ConfEdit() (ConfEditResult, error) {
 
 	// getting the configuration content so as we can compare it later
 	// to see if it has been changed
-	cnfContent, err := os.ReadFile(settings.CnfFileUsed)
+	cnfContent, err := os.ReadFile(settings.CnfPathAdmin)
 	if err != nil {
 		return CONF_FAILED, err
 	}
 
 	// open the editor
-	cmd := exec.Command(editor, settings.CnfFileUsed)
+	cmd := exec.Command(editor, settings.CnfPathAdmin)
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
@@ -55,7 +55,7 @@ func ConfEdit() (ConfEditResult, error) {
 	}
 
 	// getting the new content
-	newCnfContent, err := os.ReadFile(settings.CnfFileUsed)
+	newCnfContent, err := os.ReadFile(settings.CnfPathAdmin)
 	if err != nil {
 		return CONF_FAILED, err
 	}

--- a/core/conf.go
+++ b/core/conf.go
@@ -32,6 +32,11 @@ func ConfEdit() (ConfEditResult, error) {
 			editor = viBin
 		}
 
+		editorBin, err := exec.LookPath("editor")
+		if err == nil {
+			editor = editorBin
+		}
+
 		if editor == "" {
 			return CONF_FAILED, fmt.Errorf("no editor found in $EDITOR, nano or vi")
 		}

--- a/settings/config.go
+++ b/settings/config.go
@@ -64,10 +64,6 @@ var Cnf *Config
 var CnfFileUsed string
 
 func init() {
-	// user paths
-	homedir, _ := os.UserHomeDir()
-	viper.AddConfigPath(homedir + "/.config/abroot/")
-
 	// dev paths
 	viper.AddConfigPath("config/")
 	viper.AddConfigPath("../config/")

--- a/settings/config.go
+++ b/settings/config.go
@@ -17,6 +17,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"path/filepath"
 
 	"github.com/spf13/viper"
 )
@@ -61,30 +62,41 @@ type Config struct {
 }
 
 var Cnf *Config
-var CnfFileUsed string
+
+const CnfFileName = "abroot.json"
+
+var (
+	CnfPathSystem = filepath.Join("/usr/share/abroot/", CnfFileName)
+	CnfPathAdmin  = filepath.Join("/etc/abroot/", CnfFileName)
+	CnfPathDev1   = filepath.Join("../config/", CnfFileName)
+	CnfPathDev2   = filepath.Join("./config/", CnfFileName)
+)
 
 func init() {
+
+	// system path
+	viper.SetConfigFile(CnfPathSystem)
+	err := viper.ReadInConfig()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "could not read config file in /usr", err)
+	}
+
+	// admin path
+	viper.SetConfigFile(CnfPathAdmin)
+	err = viper.MergeInConfig()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "could not read config file in /usr", err)
+	}
+
 	// dev paths
-	viper.AddConfigPath("config/")
-	viper.AddConfigPath("../config/")
-
-	// prod paths
-	viper.AddConfigPath("/etc/abroot/")
-	viper.AddConfigPath("/usr/share/abroot/")
-
-	viper.SetConfigName("abroot")
-	viper.SetConfigType("json")
+	viper.SetConfigFile(CnfPathDev1)
+	viper.MergeInConfig()
+	viper.SetConfigFile(CnfPathDev2)
+	viper.MergeInConfig()
 
 	// VanillaOS specific defaults for backwards compatibility
 	viper.SetDefault("updateInitramfsCmd", "lpkg --unlock && /usr/sbin/update-initramfs -u && lpkg --lock")
 	viper.SetDefault("updateGrubCmd", "/usr/sbin/grub-mkconfig -o '%s'")
-
-	err := viper.ReadInConfig()
-	if err != nil {
-		return
-	}
-
-	CnfFileUsed = viper.ConfigFileUsed()
 
 	Cnf = &Config{
 		// Common


### PR DESCRIPTION
Uses configs in /usr, /etc and dev environment and merges the configurations.
Also verifies the config before writing it to /etc/abroot/abroot.json with abroot config-editor

Fixes #408 
Fixes #333 