### PR TITLE
Run cleanup when `os.Interrupt` is detected during update

### DIFF
--- a/core/system.go
+++ b/core/system.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"os/signal"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -175,6 +176,16 @@ func (s *ABSystem) RunOperation(operation ABSystemOperation, freeSpace bool) err
 
 	cq := goodies.NewCleanupQueue()
 	defer cq.Run()
+
+	interruptSignal := make(chan os.Signal, 1)
+	signal.Notify(interruptSignal, os.Interrupt)
+	go func() {
+		for _ = range interruptSignal {
+			PrintVerboseInfo("Interrupt received, cleaning up")
+			cq.Run()
+			os.Exit(0)
+		}
+	}()
 
 	// Stage 0: Check if upgrade is possible
 	// -------------------------------------


### PR DESCRIPTION
Partially fixes #363, though I admit I did not fully understand the discussion of having two separate lock files.

Seems to also partially fix #265, though again I did not fully understand the talk of 'safe points'. Should we not run the cleanup and exit script if it's past the safe point?