### PR TITLE
feat[#278]: Allow force-apply pkg changes in ABRoot

### DIFF
--- a/cmd/pkg.go
+++ b/cmd/pkg.go
@@ -45,7 +45,7 @@ func NewPkgCommand() *cmdr.Command {
 	cmd.WithBoolFlag(
 		cmdr.NewBoolFlag(
 			"force-enable-user-agreement",
-			"f",
+			"F",
 			abroot.Trans("pkg.forceEnableUserAgreementFlag"),
 			false))
 
@@ -55,6 +55,14 @@ func NewPkgCommand() *cmdr.Command {
 			"",
 			abroot.Trans("upgrade.deleteOld"),
 			false))
+
+	cmd.WithBoolFlag(
+		cmdr.NewBoolFlag(
+			"force",
+			"f",
+			abroot.Trans("pkg.force"),
+			false,
+		))
 
 	cmd.Args = cobra.MinimumNArgs(1)
 	cmd.ValidArgs = validPkgArgs
@@ -82,6 +90,12 @@ func pkg(cmd *cobra.Command, args []string) error {
 	}
 
 	forceEnableUserAgreement, err := cmd.Flags().GetBool("force-enable-user-agreement")
+	if err != nil {
+		cmdr.Error.Println(err)
+		return err
+	}
+
+	force, err := cmd.Flags().GetBool("force")
 	if err != nil {
 		cmdr.Error.Println(err)
 		return err
@@ -174,7 +188,7 @@ func pkg(cmd *cobra.Command, args []string) error {
 			return err
 		}
 
-		if len(unstaged) == 0 {
+		if len(unstaged) == 0 && !force {
 			cmdr.Info.Println(abroot.Trans("pkg.noChanges"))
 			return nil
 		}

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -67,6 +67,7 @@ pkg:
   agreementMsg: "To utilize ABRoot's abroot pkg command, explicit user agreement is required. This command facilitates package installations but introduces non-deterministic elements, impacting system trustworthiness. By consenting, you acknowledge and accept these implications, confirming your awareness of the command's potential impact on system behavior. [y/N]: "
   agreementSignFailed: "Failed to sign the agreement: %s\n"
   agreementDeclined: "You declined the agreement. The feature will stay disabled until you agree to it."
+  "force": "force apply changes even if they've already been applied"
 
 status:
   use: "status"


### PR DESCRIPTION
Fixes #278 

Replaces `-f` with `-F` for `--force-enable-user-agreement` to use it for `--force` so it's more consistent with `abroot upgrade`, wondering if this will be a problem