### PR TITLE
fix [#265 #363]: better lockfiles

### DIFF
--- a/cmd/conf.go
+++ b/cmd/conf.go
@@ -14,6 +14,8 @@ package cmd
 */
 
 import (
+	"os"
+
 	"github.com/spf13/cobra"
 
 	"github.com/vanilla-os/abroot/core"
@@ -25,7 +27,13 @@ func NewConfCommand() *cmdr.Command {
 		"config-editor",
 		abroot.Trans("cnf.long"),
 		abroot.Trans("cnf.short"),
-		cnf,
+		func(cmd *cobra.Command, args []string) error {
+			err := cnf(cmd, args)
+			if err != nil {
+				os.Exit(1)
+			}
+			return nil
+		},
 	)
 
 	return cmd

--- a/cmd/kargs.go
+++ b/cmd/kargs.go
@@ -15,6 +15,7 @@ package cmd
 
 import (
 	"errors"
+	"os"
 
 	"github.com/spf13/cobra"
 
@@ -29,7 +30,13 @@ func NewKargsCommand() *cmdr.Command {
 		"kargs edit|show",
 		abroot.Trans("kargs.long"),
 		abroot.Trans("kargs.short"),
-		kargs,
+		func(cmd *cobra.Command, args []string) error {
+			err := kargs(cmd, args)
+			if err != nil {
+				os.Exit(1)
+			}
+			return nil
+		},
 	)
 
 	cmd.Args = cobra.MatchAll(cobra.ExactArgs(1), cobra.OnlyValidArgs)

--- a/cmd/pkg.go
+++ b/cmd/pkg.go
@@ -32,7 +32,13 @@ func NewPkgCommand() *cmdr.Command {
 		"pkg add|remove|list|apply",
 		abroot.Trans("pkg.long"),
 		abroot.Trans("pkg.short"),
-		pkg,
+		func(cmd *cobra.Command, args []string) error {
+			err := pkg(cmd, args)
+			if err != nil {
+				os.Exit(1)
+			}
+			return nil
+		},
 	)
 
 	cmd.WithBoolFlag(

--- a/cmd/rollback.go
+++ b/cmd/rollback.go
@@ -27,7 +27,13 @@ func NewRollbackCommand() *cmdr.Command {
 		"rollback",
 		abroot.Trans("rollback.long"),
 		abroot.Trans("rollback.short"),
-		rollback,
+		func(cmd *cobra.Command, args []string) error {
+			err := rollback(cmd, args)
+			if err != nil {
+				os.Exit(1)
+			}
+			return nil
+		},
 	)
 
 	cmd.WithBoolFlag(

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -36,7 +36,13 @@ func NewStatusCommand() *cmdr.Command {
 		"status",
 		abroot.Trans("status.long"),
 		abroot.Trans("status.short"),
-		status,
+		func(cmd *cobra.Command, args []string) error {
+			err := status(cmd, args)
+			if err != nil {
+				os.Exit(1)
+			}
+			return nil
+		},
 	)
 
 	cmd.WithBoolFlag(

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -285,9 +285,8 @@ func getCurrentlyBootedPartition(a *core.ABRootManager) (string, string, error) 
 	if err != nil {
 		return "", "", err
 	}
-	uuid := uuid.New().String()
-	tmpBootMount := filepath.Join("/tmp", uuid)
-	err = os.Mkdir(tmpBootMount, 0o755)
+	tmpBootMount := "/run/abroot/tmp-boot-mount-status/"
+	err = os.MkdirAll(tmpBootMount, 0o755)
 	if err != nil {
 		return "", "", err
 	}

--- a/cmd/update-initramfs.go
+++ b/cmd/update-initramfs.go
@@ -14,6 +14,8 @@ package cmd
 */
 
 import (
+	"os"
+
 	"github.com/spf13/cobra"
 
 	"github.com/vanilla-os/abroot/core"
@@ -25,7 +27,13 @@ func NewUpdateInitfsCommand() *cmdr.Command {
 		"update-initramfs",
 		abroot.Trans("updateInitramfs.long"),
 		abroot.Trans("updateInitramfs.short"),
-		updateInitramfs,
+		func(cmd *cobra.Command, args []string) error {
+			err := updateInitramfs(cmd, args)
+			if err != nil {
+				os.Exit(1)
+			}
+			return nil
+		},
 	)
 
 	cmd.WithBoolFlag(

--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -62,6 +62,20 @@ func NewUpgradeCommand() *cmdr.Command {
 			abroot.Trans("upgrade.deleteOld"),
 			false))
 
+	cmd.WithBoolFlag(
+		cmdr.NewBoolFlag(
+			"cancel",
+			"",
+			abroot.Trans("upgrade.cancel"),
+			false))
+
+	cmd.WithBoolFlag(
+		cmdr.NewBoolFlag(
+			"unblock",
+			"",
+			abroot.Trans("upgrade.unblock"),
+			false))
+
 	cmd.Example = "abroot upgrade"
 
 	return cmd
@@ -84,6 +98,43 @@ func upgrade(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		cmdr.Error.Println(err)
 		return err
+	}
+
+	block, err := cmd.Flags().GetBool("cancel")
+	if err != nil {
+		cmdr.Error.Println(err)
+		return err
+	}
+
+	unblock, err := cmd.Flags().GetBool("unblock")
+	if err != nil {
+		cmdr.Error.Println(err)
+		return err
+	}
+
+	if block {
+		if dryRun {
+			cmdr.Info.Println("skipped blocking due to dry run")
+			return nil
+		}
+
+		err := core.MakeStopRequest()
+		if err != nil {
+			cmdr.Error.Println(err)
+		}
+		return err
+	}
+
+	if unblock {
+		if dryRun {
+			cmdr.Info.Println("can't use unblock and dryrun together")
+			return nil
+		}
+
+		err = core.CancelStopRequest()
+		if err != nil {
+			cmdr.Warning.Println("could not unblock operations:", err)
+		}
 	}
 
 	aBsys, err := core.NewABSystem()

--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -31,7 +31,13 @@ func NewUpgradeCommand() *cmdr.Command {
 		"upgrade",
 		abroot.Trans("upgrade.long"),
 		abroot.Trans("upgrade.short"),
-		upgrade,
+		func(cmd *cobra.Command, args []string) error {
+			err := upgrade(cmd, args)
+			if err != nil {
+				os.Exit(1)
+			}
+			return nil
+		},
 	)
 
 	cmd.WithBoolFlag(

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -123,6 +123,8 @@ upgrade:
   upgraded: "Upgraded"
   downgraded: "Downgraded"
   removed: "Removed"
+  cancel: "Temporarily block or cancel any abroot operation."
+  unblock: "Remove temporary user block."
 
 updateInitramfs:
   use: "update-initramfs"


### PR DESCRIPTION
This changes lock files in abroot in a few ways.
First of all, it puts them in /run/abroot so that they can't be created by unprivileged users.

Then it changes the lockfiles altogether and gives them a more precise function.
`/run/abroot/operation.lock` contains the PID of a running operation, so that other operations can check if it's still running

`/run/abroot/finished` is set after a successful operation when a reboot is required before running any more operations

`/run/abroot/userStop` cancels and blocks any abroot operation if possible

`/run/abroot/finalizing` is created once it's not possible to cancel the operation cleanly anymore


Fixes #265 
Fixes #363 