### PR TITLE
removes need for init partition

### DIFF
--- a/core/root.go
+++ b/core/root.go
@@ -214,25 +214,3 @@ func (a *ABRootManager) GetBoot() (partition Partition, err error) {
 	PrintVerboseInfo("ABRootManager.GetBoot", "successfully got boot partition")
 	return part, nil
 }
-
-// GetInit gets the init volume when using LVM Thin-Provisioning
-func (a *ABRootManager) GetInit() (partition Partition, err error) {
-	PrintVerboseInfo("ABRootManager.GetInit", "running...")
-
-	// Make sure Thin-Provisioning is properly configured
-	if !settings.Cnf.ThinProvisioning || settings.Cnf.ThinInitVolume == "" {
-		return Partition{}, errors.New("ABRootManager.GetInit: error: system is not configured for thin-provisioning")
-	}
-
-	diskM := NewDiskManager()
-	part, err := diskM.GetPartitionByLabel(settings.Cnf.ThinInitVolume)
-	if err != nil {
-		err = errors.New("init volume not found")
-		PrintVerboseErr("ABRootManager.GetInit", 0, err)
-
-		return Partition{}, err
-	}
-
-	PrintVerboseInfo("ABRootManager.GetInit", "successfully got init volume")
-	return part, nil
-}

--- a/settings/config.go
+++ b/settings/config.go
@@ -57,8 +57,7 @@ type Config struct {
 	PartCryptVar  string `json:"PartCryptVar"`
 
 	// Structure
-	ThinProvisioning bool   `json:"thinProvisioning"`
-	ThinInitVolume   string `json:"thinInitVolume"`
+	ThinProvisioning bool `json:"thinProvisioning"`
 }
 
 var Cnf *Config
@@ -150,7 +149,6 @@ func init() {
 
 		// Structure
 		ThinProvisioning: viper.GetBool("thinProvisioning"),
-		ThinInitVolume:   viper.GetString("thinInitVolume"),
 	}
 }
 


### PR DESCRIPTION
The init partition in VanillaOS is running dangerously low on space. (97% usage)

Even without this issue in VOS, an init partition is not necessarily needed here and should be removed, as it creates additional complexity.

This moves everything from vos-init/vos-x/ to boot/abroot/vos-x.

This is still a draft because this would cause existing systems to loose the ability to roll back, which still needs to be worked around.